### PR TITLE
fix: update package urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tinylibs/tinyspy.git"
+    "url": "git+https://github.com/tinylibs/tinybench.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/tinylibs/tinyspy/issues"
+    "url": "https://github.com/tinylibs/tinybench/issues"
   },
-  "homepage": "https://github.com/tinylibs/tinyspy#readme",
+  "homepage": "https://github.com/tinylibs/tinybench#readme",
   "devDependencies": {
     "@size-limit/preset-small-lib": "^7.0.4",
     "@size-limit/time": "^7.0.8",

--- a/package.json
+++ b/package.json
@@ -23,15 +23,8 @@
   "files": [
     "dist/**"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tinylibs/tinybench.git"
-  },
+  "repository": "tinylibs/tinybench",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/tinylibs/tinybench/issues"
-  },
-  "homepage": "https://github.com/tinylibs/tinybench#readme",
   "devDependencies": {
     "@size-limit/preset-small-lib": "^7.0.4",
     "@size-limit/time": "^7.0.8",


### PR DESCRIPTION
I noticed that the npm package still links to tinyspy. This should be released as a patch since it affects the docs on npm.