### PR TITLE
fix: rewrite sort function

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -73,7 +73,7 @@ export default class Task extends EventTarget {
     }
     await this.bench.teardown(this, 'run');
 
-    samples.sort();
+    samples.sort((a,b)=> a - b);
 
     {
       const min = samples[0]!;


### PR DESCRIPTION
Resolves #25 
previously sample.sort() was used to sort which is wrong for numbers