### PR TITLE
feat: add per-task untimed lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,16 +146,41 @@ A class that represents each benchmark task in Tinybench. It keeps track of the
 results, name, Bench instance, the task function and the number of times the task
 function has been executed.
 
-- `constructor(bench: Bench, name: string, fn: Fn)`
+- `constructor(bench: Bench, name: string, fn: Fn, opts: FnOptions = {})`
 - `bench: Bench`
 - `name: string`: task name
 - `fn: Fn`: the task function
+- `opts: FnOptions`: Task options
 - `runs: number`: the number of times the task function has been executed
 - `result?: TaskResult`: the result object
 - `async run()`: run the current task and write the results in `Task.result` object
 - `async warmup()`: warm up the current task
 - `setResult(result: Partial<TaskResult>)`: change the result object values
 - `reset()`: reset the task to make the `Task.runs` a zero-value and remove the `Task.result` object
+
+```ts
+export interface FnOptions {
+  /**
+   * An optional function that is run before iterations of this task begin
+   */
+  beforeAll?: (this: Task) => void | Promise<void>;
+
+  /**
+   * An optional function that is run before each iteration of this task
+   */
+  beforeEach?: (this: Task) => void | Promise<void>;
+
+  /**
+   * An optional function that is run after each iteration of this task
+   */
+  afterEach?: (this: Task) => void | Promise<void>;
+
+  /**
+   * An optional function that is run after all iterations of this task end
+   */
+  afterAll?: (this: Task) => void | Promise<void>;
+}
+```
 
 ## `TaskResult`
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,13 @@ export type Hook = (task: Task, mode: "warmup" | "run") => void | Promise<void>;
 - `async run()`: run the added tasks that were registered using the `add` method
 - `async warmup()`: warm up the benchmark tasks
 - `reset()`: reset each task and remove its result
-- `add(name: string, fn: Fn)`: add a benchmark task to the task map
-- - `Fn`: `() => any | Promise<any>`
+- `add(name: string, fn: Fn, opts?: FnOpts)`: add a benchmark task to the task map
+  - `Fn`: `() => any | Promise<any>`
+  - `FnOpts`: `{}`: a set of optional functions run during the benchmark lifecycle that can be used to set up or tear down test data or fixtures without affecting the timing of each task
+    - `before?: () => any | Promise<any>`: invoked once before iterations of `fn` begin
+    - `beforeEach?: () => any | Promise<any>`: invoked before each time `fn` is executed
+    - `afterEach?: () => any | Promise<any>`: invoked after each time `fn` is executed
+    - `after?: () => any | Promise<any>`: invoked once after all iterations of `fn` have finished
 - `remove(name: string)`: remove a benchmark task from the task map
 - `get results(): (TaskResult | undefined)[]`: (getter) tasks results as an array
 - `get tasks(): Task[]`: (getter) tasks as an array

--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ export type Hook = (task: Task, mode: "warmup" | "run") => void | Promise<void>;
 - `add(name: string, fn: Fn, opts?: FnOpts)`: add a benchmark task to the task map
   - `Fn`: `() => any | Promise<any>`
   - `FnOpts`: `{}`: a set of optional functions run during the benchmark lifecycle that can be used to set up or tear down test data or fixtures without affecting the timing of each task
-    - `before?: () => any | Promise<any>`: invoked once before iterations of `fn` begin
+    - `beforeAll?: () => any | Promise<any>`: invoked once before iterations of `fn` begin
     - `beforeEach?: () => any | Promise<any>`: invoked before each time `fn` is executed
     - `afterEach?: () => any | Promise<any>`: invoked after each time `fn` is executed
-    - `after?: () => any | Promise<any>`: invoked once after all iterations of `fn` have finished
+    - `afterAll?: () => any | Promise<any>`: invoked once after all iterations of `fn` have finished
 - `remove(name: string)`: remove a benchmark task from the task map
 - `get results(): (TaskResult | undefined)[]`: (getter) tasks results as an array
 - `get tasks(): Task[]`: (getter) tasks as an array

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
     "nano-staged": "^0.5.0",
-    "size-limit": "^8.0.1",
+    "size-limit": "^7.0.8",
     "tsup": "^5.11.7",
     "typescript": "^4.5.4",
     "vite": "^2.9.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,14 +16,14 @@ importers:
       eslint-config-airbnb-base: ^15.0.0
       eslint-plugin-import: ^2.26.0
       nano-staged: ^0.5.0
-      size-limit: ^8.0.1
+      size-limit: ^7.0.8
       tsup: ^5.11.7
       typescript: ^4.5.4
       vite: ^2.9.12
       vitest: ^0.14.2
     devDependencies:
-      '@size-limit/preset-small-lib': 7.0.8_size-limit@8.0.1
-      '@size-limit/time': 7.0.8_size-limit@8.0.1
+      '@size-limit/preset-small-lib': 7.0.8_size-limit@7.0.8
+      '@size-limit/time': 7.0.8_size-limit@7.0.8
       '@types/node': 18.7.13
       '@typescript-eslint/eslint-plugin': 5.35.1_ktjxjibzrfqejavile4bhmzhjq
       '@typescript-eslint/parser': 5.35.1_4rv7y5c6xz3vfxwhbrcxxi73bq
@@ -34,7 +34,7 @@ importers:
       eslint-config-airbnb-base: 15.0.0_2iahngt3u2tkbdlu6s4gkur3pu
       eslint-plugin-import: 2.26.0_lewfh47l4outvz5ytnjtm3tbm4
       nano-staged: 0.5.0
-      size-limit: 8.0.1
+      size-limit: 7.0.8
       tsup: 5.12.9_typescript@4.7.4
       typescript: 4.7.4
       vite: 2.9.14
@@ -160,7 +160,7 @@ packages:
       - supports-color
     dev: true
 
-  /@size-limit/esbuild/7.0.8_size-limit@8.0.1:
+  /@size-limit/esbuild/7.0.8_size-limit@7.0.8:
     resolution: {integrity: sha512-AzCrxJJThDvHrBNoolebYVgXu46c6HuS3fOxoXr3V0YWNM0qz81z5F3j7RruzboZnls8ZgME4WrH6GM5rB9gtA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     peerDependencies:
@@ -168,30 +168,30 @@ packages:
     dependencies:
       esbuild: 0.14.49
       nanoid: 3.3.4
-      size-limit: 8.0.1
+      size-limit: 7.0.8
     dev: true
 
-  /@size-limit/file/7.0.8_size-limit@8.0.1:
+  /@size-limit/file/7.0.8_size-limit@7.0.8:
     resolution: {integrity: sha512-1KeFQuMXIXAH/iELqIX7x+YNYDFvzIvmxcp9PrdwEoSNL0dXdaDIo9WE/yz8xvOmUcKaLfqbWkL75DM0k91WHQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     peerDependencies:
       size-limit: 7.0.8
     dependencies:
       semver: 7.3.5
-      size-limit: 8.0.1
+      size-limit: 7.0.8
     dev: true
 
-  /@size-limit/preset-small-lib/7.0.8_size-limit@8.0.1:
+  /@size-limit/preset-small-lib/7.0.8_size-limit@7.0.8:
     resolution: {integrity: sha512-CT8nIYA/c2CSD+X4rAUgwqYccQMahJ6rBnaZxvi3YKFdkXIbuGNXHNjHsYaFksgwG9P4UjG/unyO5L73f3zQBw==}
     peerDependencies:
       size-limit: 7.0.8
     dependencies:
-      '@size-limit/esbuild': 7.0.8_size-limit@8.0.1
-      '@size-limit/file': 7.0.8_size-limit@8.0.1
-      size-limit: 8.0.1
+      '@size-limit/esbuild': 7.0.8_size-limit@7.0.8
+      '@size-limit/file': 7.0.8_size-limit@7.0.8
+      size-limit: 7.0.8
     dev: true
 
-  /@size-limit/time/7.0.8_size-limit@8.0.1:
+  /@size-limit/time/7.0.8_size-limit@7.0.8:
     resolution: {integrity: sha512-CS3pHTxeQXgrrMbhlqYfSR+b4QGp1rjEcYYkByIP+X/Go88R44yp19tyBFmmCQzs2Te2BAxfq3jv8FG+54oBew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     peerDependencies:
@@ -199,7 +199,7 @@ packages:
     dependencies:
       estimo: 2.3.6
       react: 17.0.2
-      size-limit: 8.0.1
+      size-limit: 7.0.8
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2707,9 +2707,9 @@ packages:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
 
-  /size-limit/8.0.1:
-    resolution: {integrity: sha512-VHrozqkQTYfcv1OlZIRIL0x6f+xhZ3TT+RTXC5AvKn/yA+3PIWERrKWqHMJPD7G/Vi0SuBtWAn3IvCGx2/UB1g==}
-    engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
+  /size-limit/7.0.8:
+    resolution: {integrity: sha512-3h76c9E0e/nNhYLSR7IBI/bSoXICeo7EYkYjlyVqNIsu7KvN/PQmMbIXeyd2QKIF8iZKhaiZQoXLkGWbyPDtvQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     hasBin: true
     dependencies:
       bytes-iec: 3.1.1

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -5,6 +5,7 @@ import type {
   BenchEvents,
   TaskResult,
   BenchEventsMap,
+  FnOpts,
 } from 'types/index';
 import { createBenchEvent } from './event';
 import Task from './task';
@@ -100,8 +101,8 @@ export default class Bench extends EventTarget {
   /**
    * add a benchmark task to the task map
    */
-  add(name: string, fn: Fn) {
-    const task = new Task(this, name, fn);
+  add(name: string, fn: Fn, opts: FnOpts = {}) {
+    const task = new Task(this, name, fn, opts);
     this._tasks.set(name, task);
     this.dispatchEvent(createBenchEvent('add', task));
     return this;

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -5,7 +5,7 @@ import type {
   BenchEvents,
   TaskResult,
   BenchEventsMap,
-  FnOpts,
+  FnOptions,
 } from 'types/index';
 import { createBenchEvent } from './event';
 import Task from './task';
@@ -101,7 +101,7 @@ export default class Bench extends EventTarget {
   /**
    * add a benchmark task to the task map
    */
-  add(name: string, fn: Fn, opts: FnOpts = {}) {
+  add(name: string, fn: Fn, opts: FnOptions = {}) {
     const task = new Task(this, name, fn, opts);
     this._tasks.set(name, task);
     this.dispatchEvent(createBenchEvent('add', task));

--- a/src/task.ts
+++ b/src/task.ts
@@ -57,8 +57,8 @@ export default class Task extends EventTarget {
 
     await this.bench.setup(this, 'run');
 
-    if (this.opts.before != null) {
-      await this.opts.before();
+    if (this.opts.beforeAll != null) {
+      await this.opts.beforeAll();
     }
 
     while (
@@ -92,13 +92,13 @@ export default class Task extends EventTarget {
       }
     }
 
-    if (this.opts.after != null) {
-      await this.opts.after();
+    if (this.opts.afterAll != null) {
+      await this.opts.afterAll();
     }
 
     await this.bench.teardown(this, 'run');
 
-    samples.sort((a,b)=> a - b);
+    samples.sort((a, b) => a - b);
 
     {
       const min = samples[0]!;

--- a/src/task.ts
+++ b/src/task.ts
@@ -98,7 +98,7 @@ export default class Task extends EventTarget {
 
     await this.bench.teardown(this, 'run');
 
-    samples.sort((a, b) => a - b);
+    samples.sort((a,b) => a - b);
 
     {
       const min = samples[0]!;

--- a/src/task.ts
+++ b/src/task.ts
@@ -98,7 +98,7 @@ export default class Task extends EventTarget {
 
     await this.bench.teardown(this, 'run');
 
-    samples.sort((a,b) => a - b);
+    samples.sort((a,b)=> a - b);
 
     {
       const min = samples[0]!;

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,5 +1,5 @@
 import type {
-  Fn, TaskEvents, TaskResult, TaskEventsMap, FnOpts,
+  Fn, TaskEvents, TaskResult, TaskEventsMap, FnOptions,
 } from 'types/index';
 import Bench from './bench';
 import tTable from './constants';
@@ -35,9 +35,9 @@ export default class Task extends EventTarget {
   /**
    * Task options
    */
-  opts: FnOpts;
+  opts: FnOptions;
 
-  constructor(bench: Bench, name: string, fn: Fn, opts: FnOpts = {}) {
+  constructor(bench: Bench, name: string, fn: Fn, opts: FnOptions = {}) {
     super();
     this.bench = bench;
     this.name = name;
@@ -58,7 +58,7 @@ export default class Task extends EventTarget {
     await this.bench.setup(this, 'run');
 
     if (this.opts.beforeAll != null) {
-      await this.opts.beforeAll();
+      await this.opts.beforeAll.call(this);
     }
 
     while (
@@ -66,7 +66,7 @@ export default class Task extends EventTarget {
       && !this.bench.signal?.aborted
     ) {
       if (this.opts.beforeEach != null) {
-        await this.opts.beforeEach();
+        await this.opts.beforeEach.call(this);
       }
 
       let taskStart = 0;
@@ -88,12 +88,12 @@ export default class Task extends EventTarget {
       totalTime += taskTime;
 
       if (this.opts.afterEach != null) {
-        await this.opts.afterEach();
+        await this.opts.afterEach.call(this);
       }
     }
 
     if (this.opts.afterAll != null) {
-      await this.opts.afterAll();
+      await this.opts.afterAll.call(this);
     }
 
     await this.bench.teardown(this, 'run');

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -264,3 +264,29 @@ test('setup and teardown', async () => {
   expect(teardown).toBeCalledWith(fooTask, 'warmup');
   expect(teardown).toBeCalledWith(fooTask, 'run');
 });
+
+test('task before, after, beforeEach, afterEach', async () => {
+  const before = vi.fn();
+  const after = vi.fn();
+  const beforeEach = vi.fn();
+  const afterEach = vi.fn();
+  const bench = new Bench({ time: 200 });
+  bench.add('foo', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }, {
+    before,
+    after,
+    beforeEach,
+    afterEach,
+  });
+  const fooTask = bench.getTask('foo');
+
+  await bench.warmup();
+  await bench.run();
+
+  expect(before.mock.calls.length).toBe(1);
+  expect(after.mock.calls.length).toBe(1);
+  expect(beforeEach.mock.calls.length).toBeGreaterThan(1);
+  expect(afterEach.mock.calls.length).toBeGreaterThan(1);
+  expect(beforeEach.mock.calls.length).toBe(afterEach.mock.calls.length);
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -266,11 +266,20 @@ test('setup and teardown', async () => {
 });
 
 test('task beforeAll, afterAll, beforeEach, afterEach', async () => {
-  const beforeAll = vi.fn();
-  const afterAll = vi.fn();
-  const beforeEach = vi.fn();
-  const afterEach = vi.fn();
-  const bench = new Bench({ time: 200 });
+  const bench = new Bench({ time: 50 });
+
+  const beforeAll = vi.fn(function hook(this: Task) {
+    expect(this).toBe(bench.getTask('foo'));
+  });
+  const afterAll = vi.fn(function hook(this: Task) {
+    expect(this).toBe(bench.getTask('foo'));
+  });
+  const beforeEach = vi.fn(function hook(this: Task) {
+    expect(this).toBe(bench.getTask('foo'));
+  });
+  const afterEach = vi.fn(function hook(this: Task) {
+    expect(this).toBe(bench.getTask('foo'));
+  });
   bench.add('foo', async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   }, {
@@ -279,13 +288,14 @@ test('task beforeAll, afterAll, beforeEach, afterEach', async () => {
     beforeEach,
     afterEach,
   });
+  const task = bench.getTask('foo')!;
 
   await bench.warmup();
   await bench.run();
 
   expect(beforeAll.mock.calls.length).toBe(1);
   expect(afterAll.mock.calls.length).toBe(1);
-  expect(beforeEach.mock.calls.length).toBeGreaterThan(1);
-  expect(afterEach.mock.calls.length).toBeGreaterThan(1);
+  expect(beforeEach.mock.calls.length).toBe(task.runs);
+  expect(afterEach.mock.calls.length).toBe(task.runs);
   expect(beforeEach.mock.calls.length).toBe(afterEach.mock.calls.length);
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -265,27 +265,26 @@ test('setup and teardown', async () => {
   expect(teardown).toBeCalledWith(fooTask, 'run');
 });
 
-test('task before, after, beforeEach, afterEach', async () => {
-  const before = vi.fn();
-  const after = vi.fn();
+test('task beforeAll, afterAll, beforeEach, afterEach', async () => {
+  const beforeAll = vi.fn();
+  const afterAll = vi.fn();
   const beforeEach = vi.fn();
   const afterEach = vi.fn();
   const bench = new Bench({ time: 200 });
   bench.add('foo', async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   }, {
-    before,
-    after,
+    beforeAll,
+    afterAll,
     beforeEach,
     afterEach,
   });
-  const fooTask = bench.getTask('foo');
 
   await bench.warmup();
   await bench.run();
 
-  expect(before.mock.calls.length).toBe(1);
-  expect(after.mock.calls.length).toBe(1);
+  expect(beforeAll.mock.calls.length).toBe(1);
+  expect(afterAll.mock.calls.length).toBe(1);
   expect(beforeEach.mock.calls.length).toBeGreaterThan(1);
   expect(afterEach.mock.calls.length).toBeGreaterThan(1);
   expect(beforeEach.mock.calls.length).toBe(afterEach.mock.calls.length);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,26 +5,26 @@ import Task from '../src/task';
  */
 export type Fn = () => any | Promise<any>;
 
-export interface FnOpts {
+export interface FnOptions {
   /**
    * An optional function that is run before iterations of this task begin
    */
-  beforeAll?: () => any | Promise<any>;
+  beforeAll?: (this: Task) => void | Promise<void>;
 
   /**
    * An optional function that is run before each iteration of this task
    */
-  beforeEach?: () => any | Promise<any>;
+  beforeEach?: (this: Task) => void | Promise<void>;
 
   /**
    * An optional function that is run after each iteration of this task
    */
-  afterEach?: () => any | Promise<any>;
+  afterEach?: (this: Task) => void | Promise<void>;
 
   /**
    * An optional function that is run after all iterations of this task end
    */
-  afterAll?: () => any | Promise<any>;
+  afterAll?: (this: Task) => void | Promise<void>;
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,28 @@ import Task from '../src/task';
  */
 export type Fn = () => any | Promise<any>;
 
+export interface FnOpts {
+  /**
+   * An optional function that is run before iterations of this task begin
+   */
+  before?: () => any | Promise<any>;
+
+  /**
+   * An optional function that is run before each iteration of this task
+   */
+  beforeEach?: () => any | Promise<any>;
+
+  /**
+   * An optional function that is run after each iteration of this task
+   */
+  afterEach?: () => any | Promise<any>;
+
+  /**
+   * An optional function that is run after all iterations of this task end
+   */
+  after?: () => any | Promise<any>;
+}
+
 /**
  * the benchmark task result object
  */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ export interface FnOpts {
   /**
    * An optional function that is run before iterations of this task begin
    */
-  before?: () => any | Promise<any>;
+  beforeAll?: () => any | Promise<any>;
 
   /**
    * An optional function that is run before each iteration of this task
@@ -24,7 +24,7 @@ export interface FnOpts {
   /**
    * An optional function that is run after all iterations of this task end
    */
-  after?: () => any | Promise<any>;
+  afterAll?: () => any | Promise<any>;
 }
 
 /**


### PR DESCRIPTION
Adds four lifecycle hooks that can be configured to run on a per-task basis without impacting the test timings:

- `beforeAll`: run once before iterations of the task start
- `beforeEach`: run before each iteration of the task
- `afterEach`: run after each iteration of the task
- `afterAll`: run after all iterations finish

A contrived example:

```js
suite.add('my task', async () => {
  // the timed function
}, {
  beforeAll: () => {
    // start a server
  },
  beforeEach: () => {
    // set up some data that the timed function will mutate
  },
  afterEach: () => {
    // tear down any mutated data or maybe verify that the timed function did what it claims to do
  },
  afterAll: () => {
    // stop the server
  }
})
```

This is useful if, for example, you are testing several implementations of the same functionality and need to perform different operations on each implementation to bring them into the same state so that the timing data from the task function is useful data.

Fixes #32