### PR TITLE
hotfix: await the this.bench.setup call during warmup

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -172,7 +172,7 @@ export default class Task extends EventTarget {
     const startTime = this.bench.now();
     let totalTime = 0;
 
-    this.bench.setup(this, 'warmup');
+    await this.bench.setup(this, 'warmup');
     while (
       (totalTime < this.bench.warmupTime
         || this.runs < this.bench.warmupIterations)


### PR DESCRIPTION
Adds `await` for the setup method during `warmup`.

Closes #36 