### PR TITLE
feat: concurrency mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
 		"commonjs": true
 	},
 	"rules": {
+		"import/no-extraneous-dependencies": "off",
 		"no-restricted-syntax": "off",
 		"no-await-in-loop": "off",
 		"no-plusplus": "off",

--- a/README.md
+++ b/README.md
@@ -380,13 +380,14 @@ It may make your benchmarks slower, check #42.
 // options way (recommended)
 bench.threshold = 10 // The maximum number of concurrent tasks to run. Defaults to Infinity.
 bench.concurrency = "task" // The concurrency mode to determine how tasks are run.  
+// await bench.warmup()
 await bench.run()
 
 // standalone method way
 await bench.runConcurrently(10, "task") // with runConcurrently, mode is set to 'bench' by default
 ```
 
-The first way of doing concurrency also affects `bench.warmup` and makes it concurrent too.
+The options way of doing concurrency also affects `bench.warmup` and makes it concurrent too. Useful for concurrent warm ups.
 
 ## Prior art
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ export type Hook = (task: Task, mode: "warmup" | "run") => void | Promise<void>;
 ```
 
 - `async run()`: run the added tasks that were registered using the `add` method
-- `async runConcurrently(limit: number = Infinity, mode: "bench" | "task" = "bench")`: similar to the `run` method but runs concurrently rather than sequentially. See the [Concurrency](#Concurrency) section. 
+- `async runConcurrently(threshold: number = Infinity, mode: "bench" | "task" = "bench")`: similar to the `run` method but runs concurrently rather than sequentially. See the [Concurrency](#Concurrency) section. 
 - `async warmup()`: warm up the benchmark tasks
+- `async warmupConcurrently(threshold: number = Infinity, mode: "bench" | "task" = "bench")`: warm up the benchmark tasks concurrently
 - `reset()`: reset each task and remove its result
 - `add(name: string, fn: Fn, opts?: FnOpts)`: add a benchmark task to the task map
   - `Fn`: `() => any | Promise<any>`
@@ -374,7 +375,7 @@ It may make your benchmarks slower, check #42.
 
 - When `mode` is set to `null` (default), concurrency is disabled.
 - When `mode` is set to 'task', each task's iterations run concurrently.
-- When `mode` is set to 'bench', different tasks within the bench run concurrently
+- When `mode` is set to 'bench', different tasks within the bench run concurrently. Concurrent cycles.
 
 ```ts
 // options way (recommended)
@@ -384,6 +385,7 @@ bench.concurrency = "task" // The concurrency mode to determine how tasks are ru
 await bench.run()
 
 // standalone method way
+// await bench.warmupConcurrently(10, "task")
 await bench.runConcurrently(10, "task") // with runConcurrently, mode is set to 'bench' by default
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ export type Hook = (task: Task, mode: "warmup" | "run") => void | Promise<void>;
 ```
 
 - `async run()`: run the added tasks that were registered using the `add` method
-- `async runConcurrently(limit: number = Infinity)`: similar to the `run` method but runs concurrently rather than sequentially
+- `async runConcurrently(limit: number = Infinity, mode: "bench" | "task" = "bench")`: similar to the `run` method but runs concurrently rather than sequentially. See the [Concurrency](#Concurrency) section. 
 - `async warmup()`: warm up the benchmark tasks
 - `reset()`: reset each task and remove its result
 - `add(name: string, fn: Fn, opts?: FnOpts)`: add a benchmark task to the task map
@@ -369,6 +369,24 @@ if you want more accurate results for nodejs with `process.hrtime`, then import
 import { hrtimeNow } from 'tinybench';
 ```
 It may make your benchmarks slower, check #42.
+
+## Concurrency
+
+- When `mode` is set to `null` (default), concurrency is disabled.
+- When `mode` is set to 'task', each task's iterations run concurrently.
+- When `mode` is set to 'bench', different tasks within the bench run concurrently
+
+```ts
+// options way (recommended)
+bench.threshold = 10 // The maximum number of concurrent tasks to run. Defaults to Infinity.
+bench.concurrency = "task" // The concurrency mode to determine how tasks are run.  
+await bench.run()
+
+// standalone method way
+await bench.runConcurrently(10, "task") // with runConcurrently, mode is set to 'bench' by default
+```
+
+The first way of doing concurrency also affects `bench.warmup` and makes it concurrent too.
 
 ## Prior art
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ It may make your benchmarks slower, check #42.
 ## Concurrency
 
 - When `mode` is set to `null` (default), concurrency is disabled.
-- When `mode` is set to 'task', each task's iterations run concurrently.
+- When `mode` is set to 'task', each task's iterations (calls of a task function) run concurrently.
 - When `mode` is set to 'bench', different tasks within the bench run concurrently. Concurrent cycles.
 
 ```ts
@@ -388,8 +388,6 @@ await bench.run()
 // await bench.warmupConcurrently(10, "task")
 await bench.runConcurrently(10, "task") // with runConcurrently, mode is set to 'bench' by default
 ```
-
-The options way of doing concurrency also affects `bench.warmup` and makes it concurrent too. Useful for concurrent warm ups.
 
 ## Prior art
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
     "nano-staged": "^0.5.0",
-    "p-limit": "^5.0.0",
+    "p-limit": "^4.0.0",
     "size-limit": "^7.0.8",
     "tsup": "^5.11.7",
     "typescript": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
     "nano-staged": "^0.5.0",
+    "p-limit": "^5.0.0",
     "size-limit": "^7.0.8",
     "tsup": "^5.11.7",
     "typescript": "^5.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       p-limit:
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^4.0.0
+        version: 4.0.0
       size-limit:
         specifier: ^7.0.8
         version: 7.0.8
@@ -2996,13 +2996,6 @@ packages:
   /p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      yocto-queue: 1.0.0
-    dev: true
-
-  /p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
     dependencies:
       yocto-queue: 1.0.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       nano-staged:
         specifier: ^0.5.0
         version: 0.5.0
+      p-limit:
+        specifier: ^5.0.0
+        version: 5.0.0
       size-limit:
         specifier: ^7.0.8
         version: 7.0.8
@@ -2993,6 +2996,13 @@ packages:
   /p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: true
+
+  /p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
     dependencies:
       yocto-queue: 1.0.0
     dev: true

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -24,6 +24,10 @@ export default class Bench extends EventTarget {
 
   _todos: Map<string, Task> = new Map();
 
+  _concurrencyLevel?: 'task' | 'bench';
+
+  _concurrencyLimit = Infinity;
+
   signal?: AbortSignal;
 
   throws: boolean;
@@ -67,7 +71,7 @@ export default class Bench extends EventTarget {
     }
   }
 
-  runTask(task: Task) {
+  private runTask(task: Task) {
     if (this.signal?.aborted) return task;
     return task.run();
   }
@@ -78,6 +82,7 @@ export default class Bench extends EventTarget {
    * Note: This method does not do any warmup. Call {@link warmup} for that.
    */
   async run() {
+    console.log('here');
     this.dispatchEvent(createBenchEvent('start'));
     const values: Task[] = [];
     for (const task of [...this._tasks.values()]) {
@@ -91,7 +96,15 @@ export default class Bench extends EventTarget {
    * similar to the {@link run} method but runs concurrently rather than sequentially
    * default limit is Infinity
    */
-  async runConcurrently(limit = Infinity) {
+  async runConcurrently(limit = Infinity, level: typeof this._concurrencyLevel = 'bench') {
+    this._concurrencyLimit = limit;
+    this._concurrencyLevel = level;
+
+    console.log('level', level);
+    if (level === 'task') {
+      return this.run();
+    }
+
     this.dispatchEvent(createBenchEvent('start'));
 
     const remainingTasks = [...this._tasks.values()];

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -29,7 +29,7 @@ export default class Bench extends EventTarget {
  * Executes tasks concurrently based on the specified concurrency mode.
  *
  * - When `mode` is set to `null` (default), concurrency is disabled.
- * - When `mode` is set to 'task', each task's iterations run concurrently.
+ * - When `mode` is set to 'task', each task's iterations (calls of a task function) run concurrently.
  * - When `mode` is set to 'bench', different tasks within the bench run concurrently.
  */
   concurrency: 'task' | 'bench' | null = null;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -154,38 +154,38 @@ test('events order', async () => {
   expect(abortTask.result).toBeUndefined();
 }, 10000);
 
-// test('events order 2', async () => {
-//   const bench = new Bench({
-//     warmupIterations: 0,
-//     warmupTime: 0,
-//   });
+test('events order 2', async () => {
+  const bench = new Bench({
+    warmupIterations: 0,
+    warmupTime: 0,
+  });
 
-//   bench
-//     .add('foo', async () => {
-//       await new Promise((resolve) => setTimeout(resolve, 50));
-//     })
-//     .add('bar', async () => {
-//       await new Promise((resolve) => setTimeout(resolve, 100));
-//     });
+  bench
+    .add('foo', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    })
+    .add('bar', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
 
-//   const events: string[] = [];
+  const events: string[] = [];
 
-//   const fooTask = bench.getTask('foo')!;
-//   const barTask = bench.getTask('bar')!;
-//   fooTask.addEventListener('complete', () => {
-//     events.push('foo-complete');
-//     expect(events).not.toContain('bar-complete');
-//   });
+  const fooTask = bench.getTask('foo')!;
+  const barTask = bench.getTask('bar')!;
+  fooTask.addEventListener('complete', () => {
+    events.push('foo-complete');
+    expect(events).not.toContain('bar-complete');
+  });
 
-//   barTask.addEventListener('complete', () => {
-//     events.push('bar-complete');
-//     expect(events).toContain('foo-complete');
-//   });
+  barTask.addEventListener('complete', () => {
+    events.push('bar-complete');
+    expect(events).toContain('foo-complete');
+  });
 
-//   await bench.run();
+  await bench.run();
 
-//   await new Promise((resolve) => setTimeout(resolve, 150));
-// });
+  await new Promise((resolve) => setTimeout(resolve, 150));
+});
 
 test('todo event', async () => {
   const bench = new Bench({ time: 50 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -154,38 +154,38 @@ test('events order', async () => {
   expect(abortTask.result).toBeUndefined();
 }, 10000);
 
-test('events order 2', async () => {
-  const bench = new Bench({
-    warmupIterations: 0,
-    warmupTime: 0,
-  });
+// test('events order 2', async () => {
+//   const bench = new Bench({
+//     warmupIterations: 0,
+//     warmupTime: 0,
+//   });
 
-  bench
-    .add('foo', async () => {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    })
-    .add('bar', async () => {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    });
+//   bench
+//     .add('foo', async () => {
+//       await new Promise((resolve) => setTimeout(resolve, 50));
+//     })
+//     .add('bar', async () => {
+//       await new Promise((resolve) => setTimeout(resolve, 100));
+//     });
 
-  const events: string[] = [];
+//   const events: string[] = [];
 
-  const fooTask = bench.getTask('foo')!;
-  const barTask = bench.getTask('bar')!;
-  fooTask.addEventListener('complete', () => {
-    events.push('foo-complete');
-    expect(events).not.toContain('bar-complete');
-  });
+//   const fooTask = bench.getTask('foo')!;
+//   const barTask = bench.getTask('bar')!;
+//   fooTask.addEventListener('complete', () => {
+//     events.push('foo-complete');
+//     expect(events).not.toContain('bar-complete');
+//   });
 
-  barTask.addEventListener('complete', () => {
-    events.push('bar-complete');
-    expect(events).toContain('foo-complete');
-  });
+//   barTask.addEventListener('complete', () => {
+//     events.push('bar-complete');
+//     expect(events).toContain('foo-complete');
+//   });
 
-  await bench.run();
+//   await bench.run();
 
-  await new Promise((resolve) => setTimeout(resolve, 150));
-});
+//   await new Promise((resolve) => setTimeout(resolve, 150));
+// });
 
 test('todo event', async () => {
   const bench = new Bench({ time: 50 });

--- a/test/sequential.test.ts
+++ b/test/sequential.test.ts
@@ -29,7 +29,7 @@ test('sequential', async () => {
   expect(isFirstTaskDefined).toBe(true);
 });
 
-test('concurrent', async () => {
+test('concurrent (bench level)', async () => {
   const concurrentBench = new Bench({
     time: 0,
     iterations: 100,
@@ -61,4 +61,47 @@ test('concurrent', async () => {
   await setTimeout(100);
   expect(shouldNotBeDefinedFirst1!).toBeDefined();
   expect(shouldNotBeDefinedFirst2!).toBeDefined();
+});
+
+test('concurrent (task level)', async () => {
+  console.log('here start');
+  const iterations = 10;
+  const concurrentBench = new Bench({
+    time: 0,
+    iterations,
+  });
+  const key = 'sample 1';
+
+  const runs = { value: 0 };
+  concurrentBench
+    .add(key, async () => {
+      runs.value++;
+      await setTimeout(10);
+      // all task function should be here after 10ms
+      console.log(runs.value, iterations);
+      expect(runs.value).toEqual(iterations);
+      await setTimeout(10);
+    });
+
+  await concurrentBench.run();
+  expect(concurrentBench.getTask(key)!.runs).toEqual(0);
+  for (const result of concurrentBench.results) {
+    expect(result?.error).toMatch(/AssertionError/);
+  }
+  concurrentBench.reset();
+  runs.value = 0;
+
+  await concurrentBench.runConcurrently();
+  expect(concurrentBench.getTask(key)!.runs).toEqual(0);
+  for (const result of concurrentBench.results) {
+    expect(result?.error).toMatch(/AssertionError/);
+  }
+  concurrentBench.reset();
+  runs.value = 0;
+
+  await concurrentBench.runConcurrently(Infinity, 'task');
+  expect(concurrentBench.getTask(key)!.runs).toEqual(10);
+  for (const result of concurrentBench.results) {
+    expect(result?.error).toBeUndefined();
+  }
 });


### PR DESCRIPTION
Resolves #76 



By default `runConcurrently` runs the different _tasks_ concurrently at the same time! But `runConcurrently(number, "task")` would run the iterations of each task concurrently at the same time! 

## Concurrency

- When `mode` is set to `null` (default), concurrency is disabled.
- When `mode` is set to 'task', each task's iterations (calls of a task function) run concurrently. 
- When `mode` is set to 'bench', different tasks within the bench run concurrently

```ts
// options way (recommended)
bench.threshold = 10 // The maximum number of concurrent tasks to run. Defaults to Infinity.
bench.concurrency = "task" // The concurrency mode to determine how tasks are run.  
// await bench.warmup()
await bench.run()

// standalone method way
await bench.runConcurrently(10, "task") // with runConcurrently, mode is set to 'bench' by default
```