### PR TITLE
feat: improve the latency and throughput formatting in the result table

### DIFF
--- a/src/bench.ts
+++ b/src/bench.ts
@@ -21,6 +21,7 @@ import {
 import { createBenchEvent } from './event'
 import { Task } from './task'
 import {
+  formatNumber,
   invariant,
   type JSRuntime,
   mToNs,
@@ -254,12 +255,12 @@ export class Bench extends EventTarget {
             }
           : (convert?.(task) ?? {
               'Task name': task.name,
-              'Latency average (ns)': `${mToNs(task.result.latency.mean).toFixed(2)} \xb1 ${task.result.latency.rme.toFixed(2)}%`,
+              'Latency average (ns)': `${formatNumber(mToNs(task.result.latency.mean), 5, 2)} \xb1 ${task.result.latency.rme.toFixed(2)}%`,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              'Latency median (ns)': `${mToNs(task.result.latency.p50!).toFixed(2)}${Number.parseFloat(mToNs(task.result.latency.mad!).toFixed(2)) > 0 ? ` \xb1 ${mToNs(task.result.latency.mad!).toFixed(2)}` : ''}`,
+              'Latency median (ns)': +formatNumber(mToNs(task.result.latency.p50!), 5, 2),
               'Throughput average (ops/s)': `${task.result.throughput.mean.toFixed(0)} \xb1 ${task.result.throughput.rme.toFixed(2)}%`,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              'Throughput median (ops/s)': `${task.result.throughput.p50!.toFixed(0)}${Number.parseInt(task.result.throughput.mad!.toFixed(0), 10) > 0 ? ` \xb1 ${task.result.throughput.mad!.toFixed(0)}` : ''}`,
+              'Throughput median (ops/s)': Math.round(task.result.throughput.p50!),
               Samples: task.result.latency.samples.length,
             })
         /* eslint-enable perfectionist/sort-objects */

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -260,7 +260,7 @@ export class Bench extends EventTarget {
               'Latency median (ns)': `${formatNumber(mToNs(task.result.latency.p50!), 5, 2)} \xb1 ${mToNs(task.result.latency.mad!).toFixed(2)}`,
               'Throughput average (ops/s)': `${task.result.throughput.mean.toFixed(0)} \xb1 ${task.result.throughput.rme.toFixed(2)}%`,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              'Throughput median (ops/s)': Math.round(task.result.throughput.p50!),
+              'Throughput median (ops/s)': `{Math.round(task.result.throughput.p50!)} \xb1 ${Math.round(task.result.throughput.mad)}`,
               Samples: task.result.latency.samples.length,
             })
         /* eslint-enable perfectionist/sort-objects */

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -257,7 +257,7 @@ export class Bench extends EventTarget {
               'Task name': task.name,
               'Latency average (ns)': `${formatNumber(mToNs(task.result.latency.mean), 5, 2)} \xb1 ${task.result.latency.rme.toFixed(2)}%`,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              'Latency median (ns)': +formatNumber(mToNs(task.result.latency.p50!), 5, 2),
+              'Latency median (ns)': `${formatNumber(mToNs(task.result.latency.p50!), 5, 2)} \xb1 ${mToNs(task.result.latency.mad!).toFixed(2)}`,
               'Throughput average (ops/s)': `${task.result.throughput.mean.toFixed(0)} \xb1 ${task.result.throughput.rme.toFixed(2)}%`,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               'Throughput median (ops/s)': Math.round(task.result.throughput.p50!),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,6 +135,29 @@ export const nToMs = (ns: number) => ns / 1e6
  */
 export const mToNs = (ms: number) => ms * 1e6
 
+/**
+ * @param x number to format
+ * @param targetDigits number of digits in the output to aim for
+ * @param maxFractionDigits hard limit for the number of digits after the decimal dot
+ * @returns formatted number
+ */
+export const formatNumber = (x: number, targetDigits: number, maxFractionDigits: number): string => {
+  // Round large numbers to integers, but not to multiples of 10.
+  // The actual number of significant digits may be more than `targetDigits`.
+  if (Math.abs(x) >= 10 ** targetDigits) {
+    return x.toFixed()
+  }
+
+  // Round small numbers to have `maxFractionDigits` digits after the decimal dot.
+  // The actual number of significant digits may be less than `targetDigits`.
+  if (Math.abs(x) < 10 ** (targetDigits - maxFractionDigits)) {
+    return x.toFixed(maxFractionDigits)
+  }
+
+  // Round medium magnitude numbers to have exactly `targetDigits` significant digits.
+  return x.toPrecision(targetDigits)
+}
+
 let hrtimeBigint: () => bigint
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
 if (typeof (globalThis as any).process?.hrtime?.bigint === 'function') {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -117,11 +117,11 @@ test('bench table (async)', async () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Latency average (ns)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      'Latency median (ns)': expect.any(String),
+      'Latency median (ns)': expect.any(Number),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Throughput average (ops/s)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      'Throughput median (ops/s)': expect.any(String),
+      'Throughput median (ops/s)': expect.any(Number),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       Samples: expect.any(Number),
     },
@@ -164,11 +164,11 @@ test('bench table (sync)', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Latency average (ns)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      'Latency median (ns)': expect.any(String),
+      'Latency median (ns)': expect.any(Number),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Throughput average (ops/s)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      'Throughput median (ops/s)': expect.any(String),
+      'Throughput median (ops/s)': expect.any(Number),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       Samples: expect.any(Number),
     },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -168,7 +168,7 @@ test('bench table (sync)', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Throughput average (ops/s)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      'Throughput median (ops/s)': expect.any(Number),
+      'Throughput median (ops/s)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       Samples: expect.any(Number),
     },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -117,7 +117,7 @@ test('bench table (async)', async () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Latency average (ns)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      'Latency median (ns)': expect.any(Number),
+      'Latency median (ns)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Throughput average (ops/s)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -164,7 +164,7 @@ test('bench table (sync)', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Latency average (ns)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      'Latency median (ns)': expect.any(Number),
+      'Latency median (ns)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Throughput average (ops/s)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -121,7 +121,7 @@ test('bench table (async)', async () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'Throughput average (ops/s)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      'Throughput median (ops/s)': expect.any(Number),
+      'Throughput median (ops/s)': expect.any(String),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       Samples: expect.any(Number),
     },

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest'
+
+import { formatNumber } from '../src/utils'
+
+test('formatting integers', () => {
+  expect(formatNumber(123456, 5, 2)).toBe('123456')
+  expect(formatNumber(12345, 5, 2)).toBe('12345')
+  expect(formatNumber(1234, 5, 2)).toBe('1234.0')
+  expect(formatNumber(123, 5, 2)).toBe('123.00')
+  expect(formatNumber(12, 5, 2)).toBe('12.00')
+  expect(formatNumber(1, 5, 2)).toBe('1.00')
+  expect(formatNumber(0, 5, 2)).toBe('0.00')
+  expect(formatNumber(-1, 5, 2)).toBe('-1.00')
+})
+
+test('formatting floats', () => {
+  expect(formatNumber(123456.789, 5, 2)).toBe('123457')
+  expect(formatNumber(12345.6789, 5, 2)).toBe('12346')
+  expect(formatNumber(1234.56789, 5, 2)).toBe('1234.6')
+  expect(formatNumber(123.456789, 5, 2)).toBe('123.46')
+  expect(formatNumber(12.3456789, 5, 2)).toBe('12.35')
+  expect(formatNumber(-12.3456789, 5, 2)).toBe('-12.35')
+})


### PR DESCRIPTION
Make the result table a bit more compact, as per the discussion under issue #231

- Reduce the number of latency and throughput digits, because the least significant ones were just noise.
- Drop the ± part from the medians. They indicated the distance between the two middle elements when there was even number of them, which isn't particularly useful.
- Output the medians as numbers to get rid of the quotes.

Example result table for `simple benchmark gc`:

```
┌─────────┬───────────────┬──────────────────────┬─────────────────────┬────────────────────────────┬───────────────────────────┬─────────┐
│ (index) │ Task name     │ Latency average (ns) │ Latency median (ns) │ Throughput average (ops/s) │ Throughput median (ops/s) │ Samples │
├─────────┼───────────────┼──────────────────────┼─────────────────────┼────────────────────────────┼───────────────────────────┼─────────┤
│ 0       │ 'faster task' │ '3578.7 ± 2.83%'     │ 3125                │ '314227 ± 0.18%'           │ 320000                    │ 27944   │
│ 1       │ 'slower task' │ '1164166 ± 3.01%'    │ 1192251             │ '1321 ± 67.29%'            │ 839                       │ 86      │
└─────────┴───────────────┴──────────────────────┴─────────────────────┴────────────────────────────┴───────────────────────────┴─────────┘
```