### PR TITLE
Print the median absolute deviations as percentages

### DIFF
--- a/src/bench.ts
+++ b/src/bench.ts
@@ -246,22 +246,23 @@ export class Bench extends EventTarget {
   ): (null | Record<string, number | string | undefined>)[] {
     return this.tasks.map(task => {
       if (task.result) {
+        const { error, latency, throughput } = task.result
         /* eslint-disable perfectionist/sort-objects */
-        return task.result.error
+        return error
           ? {
               'Task name': task.name,
-              Error: task.result.error.message,
-              Stack: task.result.error.stack,
+              Error: error.message,
+              Stack: error.stack,
             }
           : (convert?.(task) ?? {
               'Task name': task.name,
-              'Latency avg (ns)': `${formatNumber(mToNs(task.result.latency.mean), 5, 2)} \xb1 ${task.result.latency.rme.toFixed(2)}%`,
+              'Latency avg (ns)': `${formatNumber(mToNs(latency.mean), 5, 2)} \xb1 ${latency.rme.toFixed(2)}%`,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              'Latency med (ns)': `${formatNumber(mToNs(task.result.latency.p50!), 5, 2)} \xb1 ${formatNumber(mToNs(task.result.latency.mad!), 5, 2)}`,
-              'Throughput avg (ops/s)': `${Math.round(task.result.throughput.mean).toString()} \xb1 ${task.result.throughput.rme.toFixed(2)}%`,
+              'Latency med (ns)': `${formatNumber(mToNs(latency.p50!), 5, 2)} \xb1 ${formatNumber(mToNs(latency.mad!), 5, 2)}`,
+              'Throughput avg (ops/s)': `${Math.round(throughput.mean).toString()} \xb1 ${throughput.rme.toFixed(2)}%`,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              'Throughput med (ops/s)': `${Math.round(task.result.throughput.p50!).toString()} \xb1 ${Math.round(task.result.throughput.mad!).toString()}`,
-              Samples: task.result.latency.samples.length,
+              'Throughput med (ops/s)': `${Math.round(throughput.p50!).toString()} \xb1 ${Math.round(throughput.mad!).toString()}`,
+              Samples: latency.samples.length,
             })
         /* eslint-enable perfectionist/sort-objects */
       }


### PR DESCRIPTION
They are easier to interpret and compare this way.

Example output:
```
┌─────────┬───────────────┬───────────────────┬───────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name     │ Latency avg (ns)  │ Latency med (ns)  │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼───────────────┼───────────────────┼───────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ 'faster task' │ '3610.6 ± 2.97%'  │ '3125.0 ± 10.7%'  │ '314695 ± 0.18%'       │ '320000 ± 10.3%'       │ 27696   │
│ 1       │ 'slower task' │ '1191889 ± 1.01%' │ '1192708 ± 0.60%' │ '841 ± 1.05%'          │ '838 ± 0.60%'          │ 84      │
└─────────┴───────────────┴───────────────────┴───────────────────┴────────────────────────┴────────────────────────┴─────────┘
```