### PR TITLE
feat!: esm-only

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -2,9 +2,5 @@
   {
     "path": "dist/index.js",
     "limit": "12 kB"
-  },
-  {
-    "path": "dist/index.cjs",
-    "limit": "12 kB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -26,17 +26,13 @@
     "release": "bumpp package.json --commit --push --tag",
     "test": "vitest --retry=5 --run"
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "require": {
-      "types": "./dist/index.d.cts",
-      "require": "./dist/index.cjs"
-    },
-    "import": {
+    ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,9 @@
   "compilerOptions": {
     "target": "ES2018",
     "strict": true,
-    "esModuleInterop": true,
     "moduleResolution": "Bundler",
     "noEmit": true,
     "noUncheckedIndexedAccess": true,
-    "baseUrl": ".",
     "skipLibCheck": true,
     "lib": []
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   clean: true,
   dts: true,
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   minify: false,
   minifyIdentifiers: true,
   minifySyntax: true,


### PR DESCRIPTION
Moves to being esm-only.

Unlike other tinylib projects, this one keeps `tsup` since we bundle dependencies still.

If we ever decide not to bundle dependencies, we should drop tsup and ship the typescript emit as-is.