### PR TITLE
feat: add mode to fn hooks

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -114,32 +114,41 @@ export type EventListener = (evt: BenchEvent) => void
 export type Fn = () => Promise<unknown> | unknown
 
 /**
+ * The task hook function signature
+ * If warmup is enabled, the hook will be called twice, once for the warmup and once for the run.
+ * @param task the task instance
+ * @param mode the mode where the hook is being called
+ */
+export type FnHook = (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
+
+/**
  * the task function options
  */
 export interface FnOptions {
   /**
    * An optional function that is run after all iterations of this task end
    */
-  afterAll?: (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
+  afterAll?: FnHook
 
   /**
    * An optional function that is run after each iteration of this task
    */
-  afterEach?: (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
+  afterEach?: FnHook
 
   /**
    * An optional function that is run before iterations of this task begin
    */
-  beforeAll?: (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
+  beforeAll?: FnHook
 
   /**
    * An optional function that is run before each iteration of this task
    */
-  beforeEach?: (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
+  beforeEach?: FnHook
 }
 
 /**
  * Hook function signature
+ * If warmup is enabled, the hook will be called twice, once for the warmup and once for the run.
  * @param task the task instance
  * @param mode the mode where the hook is being called
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,10 +116,9 @@ export type Fn = () => Promise<unknown> | unknown
 /**
  * The task hook function signature
  * If warmup is enabled, the hook will be called twice, once for the warmup and once for the run.
- * @param task the task instance
  * @param mode the mode where the hook is being called
  */
-export type FnHook = (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
+export type FnHook = (this: Task, mode?: 'run' | 'warmup') => Promise<void> | void
 
 /**
  * the task function options

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,22 +120,22 @@ export interface FnOptions {
   /**
    * An optional function that is run after all iterations of this task end
    */
-  afterAll?: (this: Task) => Promise<void> | void
+  afterAll?: (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
 
   /**
    * An optional function that is run after each iteration of this task
    */
-  afterEach?: (this: Task) => Promise<void> | void
+  afterEach?: (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
 
   /**
    * An optional function that is run before iterations of this task begin
    */
-  beforeAll?: (this: Task) => Promise<void> | void
+  beforeAll?: (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
 
   /**
    * An optional function that is run before each iteration of this task
    */
-  beforeEach?: (this: Task) => Promise<void> | void
+  beforeEach?: (this: Task, mode: 'run' | 'warmup') => Promise<void> | void
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1036,11 +1036,13 @@ test('task beforeAll, afterAll, beforeEach, afterEach (sync)', () => {
   bench.runSync()
 
   expect(beforeAll).toHaveBeenCalledTimes(2 /* warmup + run */)
+  expect(beforeAll.mock.calls).toEqual([['warmup'], ['run']])
   expect(afterAll).toHaveBeenCalledTimes(2 /* warmup + run */)
-  expect(beforeAll.mock.calls.length).toBe(afterAll.mock.calls.length)
+  expect(afterAll.mock.calls).toEqual([['warmup'], ['run']])
   expect(beforeEach).toHaveBeenCalledTimes(iterations * 2 /* warmup + run */)
+  expect(beforeEach.mock.calls).toEqual(Array(iterations).fill(['warmup']).concat(Array(iterations).fill(['run'])))
   expect(afterEach).toHaveBeenCalledTimes(iterations * 2 /* warmup + run */)
-  expect(beforeEach.mock.calls.length).toBe(afterEach.mock.calls.length)
+  expect(afterEach.mock.calls).toEqual(Array(iterations).fill(['warmup']).concat(Array(iterations).fill(['run'])))
 })
 
 test(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -990,11 +990,13 @@ test('task beforeAll, afterAll, beforeEach, afterEach (async)', async () => {
   await bench.run()
 
   expect(beforeAll).toHaveBeenCalledTimes(2 /* warmup + run */)
+  expect(beforeAll.mock.calls).toEqual([['warmup'], ['run']])
   expect(afterAll).toHaveBeenCalledTimes(2 /* warmup + run */)
-  expect(beforeAll.mock.calls.length).toBe(afterAll.mock.calls.length)
+  expect(afterAll.mock.calls).toEqual([['warmup'], ['run']])
   expect(beforeEach).toHaveBeenCalledTimes(iterations * 2 /* warmup + run */)
+  expect(beforeEach.mock.calls).toEqual(Array(iterations).fill(['warmup']).concat(Array(iterations).fill(['run'])))
   expect(afterEach).toHaveBeenCalledTimes(iterations * 2 /* warmup + run */)
-  expect(beforeEach.mock.calls.length).toBe(afterEach.mock.calls.length)
+  expect(afterEach.mock.calls).toEqual(Array(iterations).fill(['warmup']).concat(Array(iterations).fill(['run'])))
 })
 
 test('task beforeAll, afterAll, beforeEach, afterEach (sync)', () => {


### PR DESCRIPTION
Provide a way to check the mode for fn hooks that is consistent with setup and teardown.