### PR TITLE
feat: add AbortSignal support at the task level

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,13 @@ export interface FnOptions {
    * An optional function that is run before each iteration of this task
    */
   beforeEach?: FnHook
+
+  /**
+   * An AbortSignal for aborting this specific task
+   *
+   * If not provided, falls back to {@link BenchOptions.signal}
+   */
+  signal?: AbortSignal
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1348,3 +1348,229 @@ test('uses overridden task durations (sync)', () => {
   expect(bench.getTask('foo')?.result?.latency.min).toBe(150)
   expect(bench.getTask('foo')?.result?.latency.max).toBe(150)
 })
+
+test('task-level abort: aborts individual task without affecting others (async)', async () => {
+  const controller = new AbortController()
+  const bench = new Bench({ iterations: 16, time: 100 })
+
+  bench.add('task1', async () => {
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }, { signal: controller.signal })
+
+  bench.add('task2', async () => {
+    await new Promise(resolve => setTimeout(resolve, 50))
+  })
+
+  controller.abort()
+
+  await bench.run()
+
+  expect(bench.tasks.length).toEqual(2)
+
+  const task1 = bench.getTask('task1')
+  expect(task1?.result?.aborted).toBe(true)
+  expect(task1?.runs).toBe(0) // No iterations ran
+
+  const task2 = bench.getTask('task2')
+  expect(task2?.result?.aborted).toBe(false)
+  expect(task2?.runs).toBeGreaterThan(0)
+})
+
+test('task-level abort: aborts individual task without affecting others (sync)', () => {
+  const controller = new AbortController()
+  const bench = new Bench({ iterations: 16, time: 100 })
+
+  bench.add('task1', () => {
+    sleep(50)
+  }, { signal: controller.signal })
+
+  bench.add('task2', () => {
+    sleep(50)
+  })
+
+  controller.abort()
+
+  bench.runSync()
+
+  expect(bench.tasks.length).toEqual(2)
+
+  const task1 = bench.getTask('task1')
+  expect(task1?.result?.aborted).toBe(true)
+  expect(task1?.runs).toBe(0)
+
+  const task2 = bench.getTask('task2')
+  expect(task2?.result?.aborted).toBe(false)
+  expect(task2?.runs).toBeGreaterThan(0)
+})
+
+test('task-level abort: aborts during execution (async)', async () => {
+  const controller = new AbortController()
+  const bench = new Bench({ iterations: 50, time: 200 })
+
+  bench.add('long-task', async () => {
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }, { signal: controller.signal })
+
+  setTimeout(() => { controller.abort() }, 50)
+
+  await bench.run()
+
+  const task = bench.getTask('long-task')
+  expect(task?.result?.aborted).toBe(true)
+  // Should have completed some iterations before abort
+  // Note: Due to timing, this might be 0 if abort happens very quickly
+  if (task?.runs && task.runs > 0) {
+    // If any iterations completed, verify not all completed
+    expect(task.runs).toBeLessThan(50)
+  } else {
+    // If no iterations completed, that's also acceptable (abort was very fast)
+    expect(task?.runs).toBe(0)
+  }
+})
+
+test('task-level abort: emits abort event on task', async () => {
+  const controller = new AbortController()
+  const bench = new Bench({ iterations: 16, time: 100 })
+
+  let taskAborted = false
+  let benchAborted = false
+
+  bench.add('task', async () => {
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }, { signal: controller.signal })
+
+  const task = bench.getTask('task')
+  task?.addEventListener('abort', () => { taskAborted = true })
+  bench.addEventListener('abort', () => { benchAborted = true })
+
+  controller.abort()
+  await bench.run()
+
+  expect(taskAborted).toBe(true)
+  expect(benchAborted).toBe(true)
+})
+
+test('task-level abort: task signal takes precedence over bench signal', async () => {
+  const benchController = new AbortController()
+  const taskController = new AbortController()
+  const bench = new Bench({ iterations: 16, signal: benchController.signal, time: 100 })
+
+  bench.add('task', async () => {
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }, { signal: taskController.signal })
+
+  taskController.abort()
+
+  await bench.run()
+
+  const task = bench.getTask('task')
+  expect(task?.result?.aborted).toBe(true)
+})
+
+test('task-level abort: bench-level signal aborts all tasks', async () => {
+  const benchController = new AbortController()
+  const bench = new Bench({ iterations: 16, signal: benchController.signal, time: 100 })
+
+  bench.add('task1', async () => {
+    await new Promise(resolve => setTimeout(resolve, 10))
+  })
+
+  bench.add('task2', async () => {
+    await new Promise(resolve => setTimeout(resolve, 10))
+  })
+
+  benchController.abort()
+
+  await bench.run()
+
+  expect(bench.getTask('task1')?.result?.aborted).toBe(true)
+  expect(bench.getTask('task2')?.result?.aborted).toBe(true)
+})
+
+test('task-level abort: works during async warmup phase', async () => {
+  const controller = new AbortController()
+  const bench = new Bench({ iterations: 16, time: 100, warmup: true, warmupTime: 50 })
+
+  bench.add('task', async () => {
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }, { signal: controller.signal })
+
+  controller.abort()
+
+  await bench.run()
+
+  const task = bench.getTask('task')
+  expect(task?.result?.aborted).toBe(true)
+  expect(task?.runs).toBe(0)
+})
+
+// NOTE: This test is skipped due to memory issues with concurrency and
+// task-level abort which can cause OOM errors
+test.skip('task-level abort: works with task concurrency', async () => {
+  const controller = new AbortController()
+  const bench = new Bench({ iterations: 10, time: 50 })
+  bench.concurrency = 'task'
+  bench.threshold = 2
+
+  bench.add('concurrent-task', async () => {
+    await Promise.resolve()
+  }, { signal: controller.signal })
+
+  setTimeout(() => { controller.abort() }, 20)
+
+  await bench.run()
+
+  const task = bench.getTask('concurrent-task')
+  expect(task?.result?.aborted).toBe(true)
+  // only some iterations should have run
+  expect(task?.runs).toBeGreaterThan(0)
+  expect(task?.runs).toBeLessThan(10)
+})
+
+test('task-level abort: aborted should be false if no signal is provided', async () => {
+  const bench = new Bench({ iterations: 16, time: 100 })
+
+  bench.add('task', async () => {
+    await new Promise(resolve => setTimeout(resolve, 10))
+  })
+
+  await bench.run()
+
+  const task = bench.getTask('task')
+  expect(task?.result?.aborted).toBe(false)
+  expect(task?.runs).toBeGreaterThan(0)
+})
+
+test('task-level abort: aborted should be false if a signal is provided but not aborted', async () => {
+  const controller = new AbortController()
+  const bench = new Bench({ iterations: 16, time: 100 })
+
+  bench.add('task', async () => {
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }, { signal: controller.signal })
+
+  // don't abort
+  await bench.run()
+
+  const task = bench.getTask('task')
+  expect(task?.result?.aborted).toBe(false)
+  expect(task?.runs).toBeGreaterThan(0)
+})
+
+test('task-level abort: aborted should be false if signal is aborted after run completes', async () => {
+  const controller = new AbortController()
+  const bench = new Bench({ iterations: 16, time: 100 })
+
+  bench.add('task', async () => {
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }, { signal: controller.signal })
+
+  await bench.run()
+
+  // Abort after run completes
+  controller.abort()
+
+  const task = bench.getTask('task')
+  expect(task?.result?.aborted).toBe(false)
+  expect(task?.runs).toBeGreaterThan(0)
+})


### PR DESCRIPTION
Fixes #139

This change enables `Task` to be aborted via an `AbortSignal` which falls back to a signal its
`Bench`'s signal.

It adds a `signal` prop to the `Task` class, as well as an `isAborted()` method (which could be a
getter, if you wish).

I'm wrapping `tinybench` and have confirmed this works well, as I'm able to abort (async) tasks via
the signal.

I've added tests covering intended usage and some edge cases, but it seems there may be a
memory-leak issue with concurrent tasks (I'm not sure if this is a known bug); this test
(`task-level abort: works with task concurrency`) is skipped.  If you can get it working, then
maybe it's just my environment.

I added documentation about the bench-and-task-level-`AbortSignal` support to `README.md`.  Happy
to remove if it's not needed--or I can remove the examples, or whatever.
