### PR TITLE
fix: use the same signature when implementing `BenchLike`

### DIFF
--- a/src/bench.ts
+++ b/src/bench.ts
@@ -93,7 +93,7 @@ export class Bench extends EventTarget implements BenchLike {
   /**
    * An AbortSignal to cancel the benchmark.
    */
-  readonly signal: AbortSignal | undefined
+  readonly signal?: AbortSignal
 
   /**
    * A teardown function that runs after each task execution.


### PR DESCRIPTION
When using [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes), it's not valid to define `val: Value | undefined` when implementing `val?: Value` interface:

https://github.com/vitest-dev/vitest/actions/runs/24994604053/job/73188302056?pr=10113

```txt
  Error: ../../../../node_modules/.pnpm/tinybench@6.0.0/node_modules/tinybench/dist/index.d.ts(629,15): error TS2420: Class 'Bench' incorrectly implements interface 'BenchLike'.
    Types of property 'signal' are incompatible.
      Type 'AbortSignal | undefined' is not assignable to type 'AbortSignal'.
        Type 'undefined' is not assignable to type 'AbortSignal'.
```