### PR TITLE
build: do not minify published code

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,10 +2,6 @@ import { defineConfig } from 'tsdown/config'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  minify: {
-    compress: true,
-    mangle: true,
-  },
   outExtensions: () => {
     return {
       dts: '.d.ts',

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
       js: '.js',
     }
   },
+  outputOptions: {
+    comments: false,
+  },
 })


### PR DESCRIPTION
Published code should not be minified. It has many downsides, like making debugging more difficult, making it easier to hide malicious code there, etc. End users can minify it if they are bundling Tinybench anywhere.