### PR TITLE
build: keep minify with readable output (strip comments, keep whitespace)

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
       - uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ export default defineConfig([
           autoFix: true,
           cspell: {
             words: [
+              'codegen',
               'evanwashere',
               'fastly',
               'IsHTMLDDA',

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'tsdown/config'
 export default defineConfig({
   entry: ['src/index.ts'],
   minify: {
-    // eslint-disable-next-line @cspell/spellchecker
     codegen: {
       removeWhitespace: false,
     },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from 'tsdown/config'
 export default defineConfig({
   entry: ['src/index.ts'],
   minify: {
+    // eslint-disable-next-line @cspell/spellchecker
+    codegen: {
+      removeWhitespace: false,
+    },
     compress: true,
     mangle: true,
   },
@@ -11,5 +15,8 @@ export default defineConfig({
       dts: '.d.ts',
       js: '.js',
     }
+  },
+  outputOptions: {
+    comments: false,
   },
 })


### PR DESCRIPTION
Closes #547

## Summary

Keep minification (compress + mangle) for optimal file size, but make the output readable for debugging:

- **Strip comments** (`outputOptions.comments: false`) — redundant with `.d.ts` JSDoc
- **Keep whitespace** (`codegen.removeWhitespace: false`) — code stays human-readable

Result: **38 kB** (vs 32 kB fully minified, vs 46 kB unminified). Best trade-off between size and debuggability as suggested in #547.
