### PR TITLE
test: add qualitative invariants for sub-microsecond benchmarks

### DIFF
--- a/test/bench-consistency-async.test.ts
+++ b/test/bench-consistency-async.test.ts
@@ -19,6 +19,20 @@ test('bench task runs and time consistency (async)', async () => {
   if (fooTask.result.state !== 'completed') return
 
   expect(fooTask.runs).toBeGreaterThanOrEqual(bench.iterations)
+  expect(fooTask.runs).toBe(fooTask.result.latency.samplesCount)
 
   expect(fooTask.result.totalTime).toBeGreaterThanOrEqual(bench.time)
+
+  expect(fooTask.result.latency.min).toBeLessThanOrEqual(
+    fooTask.result.latency.mean
+  )
+  expect(fooTask.result.latency.mean).toBeLessThanOrEqual(
+    fooTask.result.latency.max
+  )
+  expect(fooTask.result.latency.min).toBeLessThanOrEqual(
+    fooTask.result.latency.p50
+  )
+  expect(fooTask.result.latency.p50).toBeLessThanOrEqual(
+    fooTask.result.latency.max
+  )
 })

--- a/test/bench-consistency-sync.test.ts
+++ b/test/bench-consistency-sync.test.ts
@@ -20,6 +20,20 @@ test('bench task runs and time consistency (sync)', () => {
   if (fooTask.result.state !== 'completed') return
 
   expect(fooTask.runs).toBeGreaterThanOrEqual(bench.iterations)
+  expect(fooTask.runs).toBe(fooTask.result.latency.samplesCount)
 
   expect(fooTask.result.totalTime).toBeGreaterThanOrEqual(bench.time)
+
+  expect(fooTask.result.latency.min).toBeLessThanOrEqual(
+    fooTask.result.latency.mean
+  )
+  expect(fooTask.result.latency.mean).toBeLessThanOrEqual(
+    fooTask.result.latency.max
+  )
+  expect(fooTask.result.latency.min).toBeLessThanOrEqual(
+    fooTask.result.latency.p50
+  )
+  expect(fooTask.result.latency.p50).toBeLessThanOrEqual(
+    fooTask.result.latency.max
+  )
 })

--- a/test/sub-microsecond-async.test.ts
+++ b/test/sub-microsecond-async.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+
+import { Bench } from '../src'
+
+test('sub-microsecond noop qualitative invariants (async)', async () => {
+  const bench = new Bench({ iterations: 64, time: 100, warmup: false })
+  bench.add('noop', async () => {
+    // noop
+  })
+  await bench.run()
+
+  const fooTask = bench.getTask('noop')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+
+  expect(fooTask.result.state).toBe('completed')
+  if (fooTask.result.state !== 'completed') return
+
+  const { latency } = fooTask.result
+
+  expect(latency.samplesCount).toBeGreaterThan(0)
+  expect(latency.samplesCount).toBeGreaterThanOrEqual(bench.iterations)
+  expect(fooTask.runs).toBe(latency.samplesCount)
+
+  expect(latency.mean).toBeGreaterThanOrEqual(0)
+  expect(latency.min).toBeLessThanOrEqual(latency.mean)
+  expect(latency.mean).toBeLessThanOrEqual(latency.max)
+  expect(latency.min).toBeLessThanOrEqual(latency.p50)
+  expect(latency.p50).toBeLessThanOrEqual(latency.max)
+
+  expect(Number.isFinite(latency.p50)).toBe(true)
+  expect(Number.isFinite(latency.p75)).toBe(true)
+  expect(Number.isFinite(latency.p99)).toBe(true)
+  expect(Number.isFinite(latency.p995)).toBe(true)
+  expect(Number.isFinite(latency.p999)).toBe(true)
+
+  expect(latency.sd).toBeGreaterThanOrEqual(0)
+  expect(latency.variance).toBeGreaterThanOrEqual(0)
+})

--- a/test/sub-microsecond-sync.test.ts
+++ b/test/sub-microsecond-sync.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest'
+
+import { Bench } from '../src'
+
+test('sub-microsecond noop qualitative invariants (sync)', () => {
+  const bench = new Bench({ iterations: 64, time: 100, warmup: false })
+  bench.add('noop', () => {
+    // noop
+  })
+  bench.runSync()
+
+  const fooTask = bench.getTask('noop')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+
+  expect(fooTask.result.state).toBe('completed')
+  if (fooTask.result.state !== 'completed') return
+
+  const { latency } = fooTask.result
+
+  expect(latency.samplesCount).toBeGreaterThan(0)
+  expect(latency.samplesCount).toBeGreaterThanOrEqual(bench.iterations)
+  expect(fooTask.runs).toBe(latency.samplesCount)
+
+  expect(latency.mean).toBeGreaterThanOrEqual(0)
+  expect(latency.min).toBeLessThanOrEqual(latency.mean)
+  expect(latency.mean).toBeLessThanOrEqual(latency.max)
+  expect(latency.min).toBeLessThanOrEqual(latency.p50)
+  expect(latency.p50).toBeLessThanOrEqual(latency.max)
+
+  expect(Number.isFinite(latency.p50)).toBe(true)
+  expect(Number.isFinite(latency.p75)).toBe(true)
+  expect(Number.isFinite(latency.p99)).toBe(true)
+  expect(Number.isFinite(latency.p995)).toBe(true)
+  expect(Number.isFinite(latency.p999)).toBe(true)
+
+  expect(latency.sd).toBeGreaterThanOrEqual(0)
+  expect(latency.variance).toBeGreaterThanOrEqual(0)
+})


### PR DESCRIPTION
## Summary

Add a sync and an async test that exercise a noop task and assert the unconditional invariants on the resulting latency statistics:

- `samplesCount >= bench.iterations` (OR-loop minimum guarantee)
- `task.runs === latency.samplesCount` (structural invariant)
- `mean >= 0`, `sd >= 0`, `variance >= 0`
- `min <= mean <= max` and `min <= p50 <= max` ordering
- all percentiles are finite numbers

Extend the existing `bench-consistency-{sync,async}` tests with the same ordering and `runs/samplesCount` invariants on a slow task.

## Why

These properties hold by construction (samples are non-negative timestamp deltas, `mean`/`min`/`max`/`p50` come from the same sample set) and protect against silent regressions of the timer, sampling loop or statistics pipeline. They are not asserted anywhere today; existing tests on a noop only check field types via `toBeTypeOf('number')`.

## Risk

None — additive, test-only. No source change.