### PR TITLE
feat: add opt-in subtractTimerOverhead option

### DIFF
--- a/src/bench.ts
+++ b/src/bench.ts
@@ -24,6 +24,7 @@ import { BenchEvent } from './event'
 import { Task } from './task'
 import {
   assert,
+  calibrateTimerOverhead,
   defaultConvertTaskResultForConsoleTable,
   getTimestampProvider,
   runtime,
@@ -96,6 +97,13 @@ export class Bench extends EventTarget implements BenchLike {
   readonly signal?: AbortSignal
 
   /**
+   * Whether to subtract an estimated timestamp provider call overhead from
+   * each raw latency sample.
+   * @default false
+   */
+  readonly subtractTimerOverhead: boolean
+
+  /**
    * A teardown function that runs after each task execution.
    */
   readonly teardown: (
@@ -119,6 +127,15 @@ export class Bench extends EventTarget implements BenchLike {
    * The amount of time to run each task.
    */
   readonly time: number
+
+  /**
+   * The estimated cost of one timestamp provider call in milliseconds.
+   *
+   * `undefined` when {@link subtractTimerOverhead} is `false`.
+   * Otherwise calibrated once at construction time via
+   * {@link calibrateTimerOverhead}.
+   */
+  readonly timerOverhead: number | undefined
 
   /**
    * A timestamp provider and its related functions.
@@ -195,6 +212,10 @@ export class Bench extends EventTarget implements BenchLike {
     this.throws = restOptions.throws ?? false
     this.signal = restOptions.signal
     this.retainSamples = restOptions.retainSamples === true
+    this.subtractTimerOverhead = restOptions.subtractTimerOverhead === true
+    this.timerOverhead = this.subtractTimerOverhead
+      ? calibrateTimerOverhead(this.timestampProvider)
+      : undefined
 
     if (this.signal) {
       this.signal.addEventListener(

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,4 +37,4 @@ export type {
   TimestampProvider,
   TimestampValue,
 } from './types'
-export { formatNumber, hrtimeNow, performanceNow as now, nToMs } from './utils'
+export { calibrateTimerOverhead, formatNumber, hrtimeNow, performanceNow as now, nToMs } from './utils'

--- a/src/task.ts
+++ b/src/task.ts
@@ -569,6 +569,14 @@ export class Task extends EventTarget {
     if (isValidSamples(latencySamples)) {
       this.#runs = latencySamples.length
 
+      const overhead = this.#bench.timerOverhead
+      if (overhead !== undefined && overhead > 0) {
+        for (let i = 0; i < latencySamples.length; i++) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          latencySamples[i] = Math.max(0, latencySamples[i]! - overhead)
+        }
+      }
+
       sortSamples(latencySamples)
 
       const latencyStatistics = computeStatistics(

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,11 @@ export interface BenchLike extends EventTarget {
    */
   time: number
   /**
+   * The estimated cost of one timestamp provider call in milliseconds, or
+   * `undefined` when timer overhead subtraction is disabled.
+   */
+  timerOverhead: number | undefined
+  /**
    * The timestamp provider used by the benchmark.
    */
   timestampProvider: TimestampProvider
@@ -182,6 +187,25 @@ export interface BenchOptions {
    * An AbortSignal for aborting the benchmark.
    */
   signal?: AbortSignal
+
+  /**
+   * Whether to subtract an estimated timestamp provider call overhead from
+   * each raw latency sample.
+   *
+   * Each sample is measured as `t1 - t0` around a single call to the task
+   * function, so every raw sample is inflated by approximately one
+   * timestamp provider call cost `C`. When this option is `true`, an
+   * estimate `Ĉ` is computed once at construction time via
+   * {@link calibrateTimerOverhead}, and `max(0, raw_sample - Ĉ)` is used
+   * instead. Only location statistics (mean, percentiles) are corrected;
+   * variance, standard deviation and relative margin of error are not, since
+   * subtracting a constant does not reduce dispersion.
+   *
+   * On runtimes with a coarse timer (resolution >= 1 ms), the calibration
+   * returns `0` and this option becomes a no-op.
+   * @default false
+   */
+  subtractTimerOverhead?: boolean
 
   /**
    * Teardown function to run after each benchmark task (cycle).
@@ -403,6 +427,7 @@ export interface ResolvedBenchOptions extends BenchOptions {
   iterations: NonNullable<BenchOptions['iterations']>
   now: NonNullable<BenchOptions['now']>
   setup: NonNullable<BenchOptions['setup']>
+  subtractTimerOverhead: NonNullable<BenchOptions['subtractTimerOverhead']>
   teardown: NonNullable<BenchOptions['teardown']>
   throws: NonNullable<BenchOptions['throws']>
   time: NonNullable<BenchOptions['time']>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -333,6 +333,47 @@ const quantileSorted = (
 export const sortFn = (a: number, b: number) => a - b
 
 /**
+ * Estimates the cost of a single timestamp provider call by repeatedly
+ * measuring back-to-back calls and returning the median of the strictly
+ * positive deltas, in milliseconds.
+ *
+ * Returns `0` when no positive delta is observed, which happens when the
+ * timer resolution exceeds the cost of a call (e.g. `Date.now()` with a 1 ms
+ * grain).
+ * @param provider - the timestamp provider to calibrate
+ * @param samples - the number of back-to-back call pairs to measure
+ * @returns the estimated overhead in milliseconds, never negative
+ */
+export const calibrateTimerOverhead = (
+  provider: TimestampProvider,
+  samples = 1024
+): number => {
+  const { fn, toMs } = provider
+  const deltas: number[] = []
+
+  for (let i = 0; i < samples; i++) {
+    const a = fn()
+    const b = fn()
+    const delta = toMs(b) - toMs(a)
+    if (delta > 0) {
+      deltas.push(delta)
+    }
+  }
+
+  if (deltas.length === 0) {
+    return 0
+  }
+
+  deltas.sort(sortFn)
+  const mid = deltas.length >> 1
+  return (deltas.length & 1) === 1
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    ? deltas[mid]!
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    : (deltas[mid - 1]! + deltas[mid]!) / 2
+}
+
+/**
  * Computes the average absolute deviation from the mean.
  * @param samples - the sample
  * @param mean - the mean of the sample

--- a/test/calibrate-timer-overhead.test.ts
+++ b/test/calibrate-timer-overhead.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'vitest'
+
+import { Bench } from '../src'
+import {
+  calibrateTimerOverhead,
+  hrtimeNowTimestampProvider,
+  performanceNowTimestampProvider,
+} from '../src/utils'
+
+test('calibrateTimerOverhead returns a finite non-negative number with performanceNow', () => {
+  const overhead = calibrateTimerOverhead(performanceNowTimestampProvider)
+  expect(overhead).toBeTypeOf('number')
+  expect(overhead).toBeGreaterThanOrEqual(0)
+  expect(Number.isFinite(overhead)).toBe(true)
+})
+
+test('calibrateTimerOverhead returns a finite non-negative number with hrtimeNow', () => {
+  const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider)
+  expect(overhead).toBeTypeOf('number')
+  expect(overhead).toBeGreaterThanOrEqual(0)
+  expect(Number.isFinite(overhead)).toBe(true)
+})
+
+test('calibrateTimerOverhead returns 0 for a fixed-value provider', () => {
+  const overhead = calibrateTimerOverhead(
+    {
+      fn: () => 42,
+      fromMs: ms => ms,
+      name: 'fixed',
+      toMs: ts => ts as number,
+    },
+    256
+  )
+  expect(overhead).toBe(0)
+})
+
+test('subtractTimerOverhead defaults to false and leaves timerOverhead undefined', () => {
+  const bench = new Bench()
+  expect(bench.subtractTimerOverhead).toBe(false)
+  expect(bench.timerOverhead).toBeUndefined()
+})
+
+test('subtractTimerOverhead: true populates a finite non-negative timerOverhead', () => {
+  const bench = new Bench({ subtractTimerOverhead: true })
+  expect(bench.subtractTimerOverhead).toBe(true)
+  expect(bench.timerOverhead).toBeTypeOf('number')
+  expect(Number.isFinite(bench.timerOverhead)).toBe(true)
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  expect(bench.timerOverhead!).toBeGreaterThanOrEqual(0)
+})
+
+test('subtractTimerOverhead: true does not produce negative latency samples', () => {
+  const bench = new Bench({
+    iterations: 64,
+    subtractTimerOverhead: true,
+    time: 100,
+    warmup: false,
+  })
+  bench.add('noop', () => {
+    // noop
+  })
+  bench.runSync()
+
+  const fooTask = bench.getTask('noop')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+
+  expect(fooTask.result.state).toBe('completed')
+  if (fooTask.result.state !== 'completed') return
+
+  expect(fooTask.result.latency.min).toBeGreaterThanOrEqual(0)
+  expect(fooTask.result.latency.mean).toBeGreaterThanOrEqual(0)
+})


### PR DESCRIPTION
## Summary

Add a new `BenchOptions.subtractTimerOverhead` boolean (default `false`). When enabled, the cost of one timestamp provider call is calibrated once at construction time via the new exported `calibrateTimerOverhead` helper, and subtracted from each raw latency sample (clamped to zero) before statistics are computed.

The estimate is exposed as `bench.timerOverhead` (`number | undefined`).

## Implementation

- `calibrateTimerOverhead(provider, samples = 1024)` returns the median of the strictly positive deltas of back-to-back `now()` calls, or `0` on coarse-timer runtimes.
- The correction is applied **post-loop**, in `Task#processRunResult`, just before `sortSamples`. The sampling loop's exit condition keeps using raw timings and converges naturally even when the function under test runs at the timer grain — applying the correction inside `#measure`/`#measureSync` would zero-out samples on sub-µs functions and cause the OR-loop's `totalTime < time` condition to never be met.
- `overriddenDuration` samples are still collected via the same path and corrected uniformly; the correction is opt-in so a benchmark relying on overridden durations should leave it disabled.

## Caveats (documented in JSDoc)

Only location statistics (mean, percentiles) are corrected. Variance, sd, sem, moe and rme are unchanged because subtracting a constant does not reduce dispersion (`Var(X − C) = Var(X)` for a constant `C`). `bench.timerOverhead` is `undefined` when the option is off, `0` on runtimes whose timer resolution exceeds its own call cost.

## Risk

None for existing benchmarks — option defaults to `false`, behavior strictly unchanged when omitted. No new runtime dependency. Bundle size impact is minimal (calibration helper + 5 LOC in the hot path).