### PR TITLE
feat: dispatch warning event on timer saturation

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -20,6 +20,7 @@ import { BenchEvent } from './event'
 import {
   assert,
   computeStatistics,
+  detectTimerSaturation,
   isFnAsyncResource,
   isPromiseLike,
   isValidSamples,
@@ -606,6 +607,12 @@ export class Task extends EventTarget {
         totalTime,
       }
       /* eslint-enable perfectionist/sort-objects */
+
+      if (detectTimerSaturation(latencySamples, latencyStatistics.mad)) {
+        const warningEv = new BenchEvent('warning', this)
+        this.dispatchEvent(warningEv)
+        this.#bench.dispatchEvent(warningEv)
+      }
     } else if (this.#aborted) {
       // If aborted with no samples, still set the aborted flag
       this.#result = abortedTaskResult

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type BenchEvents =
   | 'reset' // when the reset method gets called
   | 'start' // when running the benchmarks gets started
   | 'warmup' // when the benchmarks start getting warmed up
+  | 'warning' // when timer saturation is detected for a task's latency samples
 
 /**
  * Bench events that may have an associated Task
@@ -41,7 +42,7 @@ export type BenchEventsWithError = Extract<BenchEvents, 'error'>
  */
 export type BenchEventsWithTask = Extract<
   BenchEvents,
-  'add' | 'cycle' | 'error' | 'remove'
+  'add' | 'cycle' | 'error' | 'remove' | 'warning'
 >
 
 /**
@@ -538,6 +539,7 @@ export type TaskEvents = Extract<
   | 'reset' // when the reset method gets called
   | 'start' // when running the task gets started
   | 'warmup' // when the task start getting warmed up
+  | 'warning' // when timer saturation is detected for the task's latency samples
 >
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -250,6 +250,39 @@ export const isFnAsyncResource = (fn: Fn | null | undefined): boolean => {
 }
 
 /**
+ * Detects timer saturation in a latency sample set.
+ *
+ * Saturation is reported when the timer resolution dominates the
+ * measurement, i.e. when at least one of the following holds:
+ * - more than half of the samples are zero
+ * - the number of distinct sample values is below `max(3, min(10, n / 1000))`
+ * - the median absolute deviation is zero with more than 100 samples
+ * @param samples - the latency samples
+ * @param mad - the median absolute deviation, as computed by computeStatistics
+ * @returns true when the timer resolution dominates the measurement
+ */
+export const detectTimerSaturation = (
+  samples: Samples,
+  mad: number
+): boolean => {
+  const n = samples.length
+
+  let zeroCount = 0
+  for (const s of samples) {
+    if (s === 0) zeroCount++
+  }
+  if (zeroCount * 2 > n) return true
+
+  const distinctCount = new Set(samples).size
+  const distinctThreshold = Math.max(3, Math.min(10, Math.floor(n / 1000)))
+  if (distinctCount < distinctThreshold) return true
+
+  if (n > 100 && mad === 0) return true
+
+  return false
+}
+
+/**
  * Checks if a value is a Samples type.
  * @param value - value to check
  * @returns if the value is a Samples type, meaning a non-empty array of numbers

--- a/test/utils-detect-timer-saturation.test.ts
+++ b/test/utils-detect-timer-saturation.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest'
+
+import type { Samples } from '../src/types'
+
+import { detectTimerSaturation } from '../src/utils'
+
+const asSamples = (arr: number[]): Samples => arr as unknown as Samples
+
+test('detectTimerSaturation flags more than half zero samples', () => {
+  expect(detectTimerSaturation(asSamples([0, 0, 0, 0, 0]), 0)).toBe(true)
+  expect(detectTimerSaturation(asSamples([0, 0, 0, 0, 0, 0, 1, 1, 1, 1]), 0.5))
+    .toBe(true)
+})
+
+test('detectTimerSaturation does not flag exactly half zero samples', () => {
+  expect(detectTimerSaturation(asSamples([0, 0, 0, 0, 0, 1, 2, 3, 4, 5]), 1))
+    .toBe(false)
+})
+
+test('detectTimerSaturation flags degenerate distinct counts', () => {
+  expect(detectTimerSaturation(asSamples(new Array<number>(64).fill(1)), 0))
+    .toBe(true)
+  const halfHalf = new Array<number>(500)
+    .fill(1)
+    .concat(new Array<number>(500).fill(2))
+  expect(detectTimerSaturation(asSamples(halfHalf), 0.5)).toBe(true)
+})
+
+test('detectTimerSaturation flags zero MAD with more than 100 samples', () => {
+  const arr: number[] = []
+  for (let i = 0; i < 120; i++) arr.push(5)
+  for (let i = 0; i < 80; i++) arr.push((i % 10) + 1)
+  expect(detectTimerSaturation(asSamples(arr), 0)).toBe(true)
+})
+
+test('detectTimerSaturation does not flag healthy spread samples', () => {
+  const arr: number[] = []
+  let seed = 42
+  for (let i = 0; i < 500; i++) {
+    seed = (seed * 1664525 + 1013904223) >>> 0
+    arr.push(50 + ((seed >>> 0) / 0xffffffff - 0.5) * 10)
+  }
+  expect(detectTimerSaturation(asSamples(arr), 1.5)).toBe(false)
+})


### PR DESCRIPTION
## Summary

Add a `'warning'` event to `BenchEvents` and `TaskEvents` that is dispatched on both the `Bench` and the `Task` instances when the latency samples of a task are dominated by the timer resolution.

```ts
const bench = new Bench()
bench.add('hot fn', () => regex.test(line))

bench.addEventListener('warning', evt => {
  // evt.task is typed as Task (warning is in BenchEventsWithTask)
  console.warn(`[${evt.task.name}] timer saturation detected`)
})

await bench.run()
```

## Implementation

Saturation is detected by a new internal `detectTimerSaturation(samples, mad)` helper in `src/utils.ts`. It returns `true` on any of:

- more than half of the samples are zero
- the number of distinct sample values is below `max(3, min(10, n / 1000))`
- the median absolute deviation is zero with more than 100 samples

The event is dispatched in `Task#processRunResult` right after `this.#result` is set with a `'completed'` or `'aborted-with-statistics'` state, before the `'cycle'` event so that `cycle` listeners can observe the warning state if they need to.

## Risk

Runtime-compatible — the event is purely informative and has no listener by default. The only observable change is widening the `BenchEvents` string union with `'warning'`, which is a soft compile-time signal for users who exhaustively `switch` on event types and treat unknown variants as errors. No bump beyond `feat:` is warranted because no existing API contract is removed or changed in shape.