### PR TITLE
feat: expose detected timer resolution per task

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,4 +37,10 @@ export type {
   TimestampProvider,
   TimestampValue,
 } from './types'
-export { formatNumber, hrtimeNow, performanceNow as now, nToMs } from './utils'
+export {
+  estimateResolution,
+  formatNumber,
+  hrtimeNow,
+  performanceNow as now,
+  nToMs,
+} from './utils'

--- a/src/task.ts
+++ b/src/task.ts
@@ -20,6 +20,7 @@ import { BenchEvent } from './event'
 import {
   assert,
   computeStatistics,
+  estimateResolution,
   isFnAsyncResource,
   isPromiseLike,
   isValidSamples,
@@ -71,6 +72,16 @@ export class Task extends EventTarget {
   ) => void
 
   /**
+   * The estimated effective timer resolution observed during the last run,
+   * computed as the smallest strictly positive latency sample.
+   * @returns The resolution in milliseconds, or `undefined` when no run
+   *   has produced a strictly positive sample
+   */
+  get detectedResolution (): number | undefined {
+    return this.#detectedResolution
+  }
+
+  /**
    * The name of the task.
    * @returns The task name as a string
    */
@@ -115,6 +126,11 @@ export class Task extends EventTarget {
    * The Bench instance reference
    */
   readonly #bench: BenchLike
+
+  /**
+   * The estimated effective timer resolution from the last run.
+   */
+  #detectedResolution: number | undefined = undefined
 
   /**
    * The task function
@@ -217,6 +233,7 @@ export class Task extends EventTarget {
    */
   reset (emit = true): void {
     this.#runs = 0
+    this.#detectedResolution = undefined
     this.#result = this.#aborted ? abortedTaskResult : notStartedTaskResult
 
     if (emit) this.dispatchEvent(new BenchEvent('reset', this))
@@ -570,6 +587,8 @@ export class Task extends EventTarget {
       this.#runs = latencySamples.length
 
       sortSamples(latencySamples)
+
+      this.#detectedResolution = estimateResolution(latencySamples)
 
       const latencyStatistics = computeStatistics(
         latencySamples,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -250,6 +250,22 @@ export const isFnAsyncResource = (fn: Fn | null | undefined): boolean => {
 }
 
 /**
+ * Estimates the effective timer resolution from a latency sample set as the
+ * smallest strictly positive sample observed.
+ * @param samples - the latency samples (sorted or unsorted)
+ * @returns the estimated resolution in milliseconds, or `undefined` when all samples are zero
+ */
+export const estimateResolution = (
+  samples: Samples
+): number | undefined => {
+  let min = Number.POSITIVE_INFINITY
+  for (const s of samples) {
+    if (s > 0 && s < min) min = s
+  }
+  return min === Number.POSITIVE_INFINITY ? undefined : min
+}
+
+/**
  * Checks if a value is a Samples type.
  * @param value - value to check
  * @returns if the value is a Samples type, meaning a non-empty array of numbers

--- a/test/detected-resolution.test.ts
+++ b/test/detected-resolution.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from 'vitest'
+
+import type { Samples } from '../src/types'
+
+import { Bench } from '../src'
+import { estimateResolution } from '../src/utils'
+
+const asSamples = (arr: number[]): Samples => arr as unknown as Samples
+
+test('estimateResolution returns the smallest strictly positive sample', () => {
+  expect(estimateResolution(asSamples([0, 0, 0.5, 1, 2]))).toBe(0.5)
+  expect(estimateResolution(asSamples([2, 1, 0.5, 0, 0]))).toBe(0.5)
+  expect(estimateResolution(asSamples([1, 2, 3]))).toBe(1)
+})
+
+test('estimateResolution returns undefined when all samples are zero', () => {
+  expect(estimateResolution(asSamples([0, 0, 0]))).toBeUndefined()
+})
+
+test('Task.detectedResolution is undefined before run', () => {
+  const bench = new Bench()
+  bench.add('foo', () => {
+    // noop
+  })
+  const fooTask = bench.getTask('foo')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+  expect(fooTask.detectedResolution).toBeUndefined()
+})
+
+test('Task.detectedResolution is populated after a successful run', () => {
+  const bench = new Bench({ iterations: 64, time: 100, warmup: false })
+  bench.add('foo', () => {
+    // noop
+  })
+  bench.runSync()
+  const fooTask = bench.getTask('foo')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+  expect(fooTask.result.state).toBe('completed')
+  if (fooTask.result.state !== 'completed') return
+
+  const resolution = fooTask.detectedResolution
+  if (resolution !== undefined) {
+    expect(resolution).toBeTypeOf('number')
+    expect(resolution).toBeGreaterThan(0)
+    expect(Number.isFinite(resolution)).toBe(true)
+  }
+})
+
+test('Task.detectedResolution is reset by reset()', () => {
+  const bench = new Bench({ iterations: 64, time: 100, warmup: false })
+  bench.add('foo', () => {
+    // noop
+  })
+  bench.runSync()
+  const fooTask = bench.getTask('foo')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+  fooTask.reset()
+  expect(fooTask.detectedResolution).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

Add a `Task.detectedResolution` getter (`number | undefined`) populated after each run with the smallest strictly positive latency sample observed. A new `estimateResolution` helper is exported from `src/utils.ts` and from the public entry point.

```ts
const bench = new Bench()
bench.add('hot fn', () => regex.test(line))
await bench.run()

const task = bench.getTask('hot fn')
console.log(task?.detectedResolution) // ms, or undefined
```

## Semantics

`task.detectedResolution` is:

- `undefined` before the first successful run
- `undefined` when all samples of the last run were zero (timer too coarse to resolve any iteration)
- `undefined` after `task.reset()`
- otherwise the smallest strictly positive sample, in milliseconds

The smallest non-zero sample is a conservative upper bound on the effective timer resolution: a timer of resolution `R` cannot return a non-zero delta smaller than `R`. It is more reliable than a nominal value carried by the `TimestampProvider` because it observes the actual resolution at the moment of measurement (subject to OS scheduler jitter, power-saving modes, etc.).

## Implementation

`estimateResolution` is a single linear scan; the cost is negligible relative to a benchmark run. The diagnostic is always populated — no new option, no opt-in. Useful for users who want to interpret `latency.mean` honestly for sub-µs functions, or to feed downstream guards (e.g. a CI that fails when `detectedResolution > X` due to a degraded environment).

## Risk

None — purely additive: new public getter on `Task`, new export in the entry point. No change to existing options, types, or measurement behavior.