### PR TITLE
feat: add timer-overhead correction, saturation warning, and resolution diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,10 +340,11 @@ const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
 ## Per-Sample Override (`overriddenDuration`)
 
 A task function may return an object containing `overriddenDuration`
-(in ms). That value replaces the timer-measured sample directly,
-bypassing both the timer and any overhead correction. Useful for
-externally-timed work or sub-overhead measurements that the timer
-cannot resolve.
+(in ms). That value is recorded in place of the timer-measured sample:
+the timer still brackets the task function, but its measurement is
+discarded and overhead correction is not applied to the substituted
+value. Useful for externally-timed work or sub-overhead measurements
+that the timer cannot resolve.
 
 ```ts
 bench.add('externally-timed', () => {

--- a/README.md
+++ b/README.md
@@ -317,8 +317,8 @@ import { calibrateTimerOverhead, hrtimeNowTimestampProvider } from 'tinybench'
 
 const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
   estimator: 'p05',
-  samples: 1024,
-  warmupSamples: 64,
+  pairs: 1024,
+  warmupPairs: 64,
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,9 @@ const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
 - For sub-overhead measurements (`X ≈ Ĉ`) the `max(0, …)` clamp
   truncates the lower tail and biases statistics; prefer
   `overriddenDuration` (see below).
-- On runtimes with a coarse timer (resolution >= 1 ms) the calibration
+- When the timer is too coarse to resolve the call cost — fewer than half
+  of the calibration pairs produce a positive delta (call cost `C < R / 2`,
+  e.g. a `Date.now`-class timer with `>= 1 ms` resolution) — the calibration
   returns `0` and the option becomes a no-op.
 
 ## Per-Sample Override (`overriddenDuration`)

--- a/README.md
+++ b/README.md
@@ -153,8 +153,10 @@ await bench.run()
 - When `mode` is set to 'bench', different tasks within the bench run concurrently. Concurrent cycles.
 
 ```ts
-bench.threshold = 10 // The maximum number of concurrent tasks to run. Defaults to Number.POSITIVE_INFINITY.
-bench.concurrency = 'task' // The concurrency mode to determine how tasks are run.
+const bench = new Bench({
+  concurrency: 'task', // The concurrency mode to determine how tasks are run.
+  threshold: 10, // The maximum number of concurrent tasks to run. Defaults to Number.POSITIVE_INFINITY.
+})
 await bench.run()
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Both the `Task` and `Bench` classes extend the `EventTarget` object. So you can 
 bench.addEventListener('cycle', (evt) => {
   const task = evt.task!;
 });
+
+// runs when timer saturation is detected for a task's measured samples
+bench.addEventListener('warning', (evt) => {
+  const task = evt.task!;
+  const reason = evt.reason; // 'zero-dominated' | 'low-distinct' | 'zero-mad'
+});
 ```
 
 #### [`TaskEvents`](https://tinylibs.github.io/tinybench/types/TaskEvents.html)
@@ -285,6 +291,96 @@ const bench = new Bench({
   now: Date.now,
 })
 ```
+
+## Timer Overhead Correction
+
+Each timer call (`performance.now()`, `process.hrtime.bigint()`, …) has a
+non-zero call cost `C`. For a task whose true duration `X` is comparable
+to `C`, the raw measured sample `X + C` is dominated by the timer rather
+than the task.
+
+When `subtractTimerOverhead: true` is set, an estimate `Ĉ` is computed
+once at construction time via [`calibrateTimerOverhead`](https://tinylibs.github.io/tinybench/functions/calibrateTimerOverhead.html),
+and `Math.max(0, raw_sample - Ĉ)` is used as each non-overridden sample
+before statistics are computed.
+
+```ts
+const bench = new Bench({ subtractTimerOverhead: true })
+console.log(bench.timerOverhead) // calibrated Ĉ in ms (or undefined)
+```
+
+The calibration helper is also exported for direct use, with a
+configurable estimator strategy (`'median'` default, or `'min'` / `'p05'`):
+
+```ts
+import { calibrateTimerOverhead, hrtimeNowTimestampProvider } from 'tinybench'
+
+const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
+  estimator: 'p05',
+  samples: 1024,
+  warmupSamples: 64,
+})
+```
+
+**Caveats.**
+
+- Incompatible with `concurrency: 'task'` — overhead is calibrated
+  sequentially and does not reflect concurrent execution cost.
+  Construction (and `run()`) throws if both are set.
+- For sub-overhead measurements (`X ≈ Ĉ`) the `max(0, …)` clamp
+  truncates the lower tail and biases statistics; prefer
+  `overriddenDuration` (see below).
+- On runtimes with a coarse timer (resolution >= 1 ms) the calibration
+  returns `0` and the option becomes a no-op.
+
+## Per-Sample Override (`overriddenDuration`)
+
+A task function may return an object containing `overriddenDuration`
+(in ms). That value replaces the timer-measured sample directly,
+bypassing both the timer and any overhead correction. Useful for
+externally-timed work or sub-overhead measurements that the timer
+cannot resolve.
+
+```ts
+bench.add('externally-timed', () => {
+  const start = process.hrtime.bigint()
+  doWork()
+  const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6
+  return { overriddenDuration: elapsedMs }
+})
+```
+
+Overridden samples are excluded from `Task.detectedResolution` and
+from timer-saturation detection.
+
+## Timer Diagnostics
+
+After `bench.run()` (or `runSync()`), each task exposes
+`detectedResolution` — the smallest reproducibly observed positive
+sample (in ms) among the timer-measured samples, or `undefined` when no
+positive timer measurement was seen (e.g. every sample was overridden).
+
+```ts
+const task = bench.getTask('foo')
+console.log(task?.detectedResolution) // e.g. 0.000041 (≈ 41 ns)
+```
+
+When the timer's resolution dominates a task's measured distribution
+(more than half zero samples, fewer than `max(3, min(10, ⌊n / 1000⌋))`
+distinct values, or zero MAD with `n > 100`), tinybench dispatches a
+`'warning'` event on both the task and the bench, carrying the matching
+[`TimerSaturationReason`](https://tinylibs.github.io/tinybench/types/TimerSaturationReason.html):
+
+```ts
+bench.addEventListener('warning', evt => {
+  console.warn(`timer-saturated: ${evt.task?.name} — ${evt.reason}`)
+})
+```
+
+The same heuristic and estimator are exposed as standalone helpers for
+custom analysis: [`detectTimerSaturation`](https://tinylibs.github.io/tinybench/functions/detectTimerSaturation.html),
+[`classifyTimerSaturation`](https://tinylibs.github.io/tinybench/functions/classifyTimerSaturation.html),
+and [`estimateResolution`](https://tinylibs.github.io/tinybench/functions/estimateResolution.html).
 
 ## Aborting Benchmarks
 

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -31,6 +31,9 @@ import {
   runtimeVersion,
 } from './utils'
 
+const subtractTimerOverheadConcurrencyError =
+  '`subtractTimerOverhead` cannot be used with `concurrency: "task"` — set `concurrency` to `null` or `"bench"`, or disable `subtractTimerOverhead`'
+
 /**
  * The Bench class keeps track of the benchmark tasks and controls them.
  */
@@ -218,7 +221,7 @@ export class Bench extends EventTarget implements BenchLike {
     this.subtractTimerOverhead = restOptions.subtractTimerOverhead === true
     assert(
       !(this.subtractTimerOverhead && this.concurrency === 'task'),
-      '`subtractTimerOverhead` cannot be used with `concurrency: "task"` — set `concurrency` to `null` or `"bench"`, or disable `subtractTimerOverhead`'
+      subtractTimerOverheadConcurrencyError
     )
     this.timerOverhead = this.subtractTimerOverhead
       ? calibrateTimerOverhead(this.timestampProvider)
@@ -294,7 +297,7 @@ export class Bench extends EventTarget implements BenchLike {
   async run (): Promise<Task[]> {
     assert(
       !(this.subtractTimerOverhead && this.concurrency === 'task'),
-      '`subtractTimerOverhead` cannot be used with `concurrency: "task"` — set `concurrency` to `null` or `"bench"`, or disable `subtractTimerOverhead`'
+      subtractTimerOverheadConcurrencyError
     )
     if (this.warmup) {
       await this.#warmupTasks()

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -99,6 +99,9 @@ export class Bench extends EventTarget implements BenchLike {
   /**
    * Whether to subtract an estimated timestamp provider call overhead from
    * each raw latency sample.
+   *
+   * Incompatible with `concurrency: 'task'`; the constraint is enforced
+   * at construction and at the start of {@link Bench.run}.
    * @default false
    */
   readonly subtractTimerOverhead: boolean
@@ -212,10 +215,10 @@ export class Bench extends EventTarget implements BenchLike {
     this.throws = restOptions.throws ?? false
     this.signal = restOptions.signal
     this.retainSamples = restOptions.retainSamples === true
-    this.subtractTimerOverhead = restOptions.subtractTimerOverhead ?? false
+    this.subtractTimerOverhead = restOptions.subtractTimerOverhead === true
     assert(
       !(this.subtractTimerOverhead && this.concurrency === 'task'),
-      '`subtractTimerOverhead` is incompatible with `concurrency: "task"` — overhead is calibrated sequentially and does not reflect concurrent execution cost'
+      '`subtractTimerOverhead` cannot be used with `concurrency: "task"` — set `concurrency` to `null` or `"bench"`, or disable `subtractTimerOverhead`'
     )
     this.timerOverhead = this.subtractTimerOverhead
       ? calibrateTimerOverhead(this.timestampProvider)
@@ -289,6 +292,10 @@ export class Bench extends EventTarget implements BenchLike {
    * @returns the tasks array
    */
   async run (): Promise<Task[]> {
+    assert(
+      !(this.subtractTimerOverhead && this.concurrency === 'task'),
+      '`subtractTimerOverhead` cannot be used with `concurrency: "task"` — set `concurrency` to `null` or `"bench"`, or disable `subtractTimerOverhead`'
+    )
     if (this.warmup) {
       await this.#warmupTasks()
     }

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -212,7 +212,11 @@ export class Bench extends EventTarget implements BenchLike {
     this.throws = restOptions.throws ?? false
     this.signal = restOptions.signal
     this.retainSamples = restOptions.retainSamples === true
-    this.subtractTimerOverhead = restOptions.subtractTimerOverhead === true
+    this.subtractTimerOverhead = restOptions.subtractTimerOverhead ?? false
+    assert(
+      !(this.subtractTimerOverhead && this.concurrency === 'task'),
+      '`subtractTimerOverhead` is incompatible with `concurrency: "task"` — overhead is calibrated sequentially and does not reflect concurrent execution cost'
+    )
     this.timerOverhead = this.subtractTimerOverhead
       ? calibrateTimerOverhead(this.timestampProvider)
       : undefined

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -103,8 +103,10 @@ export class Bench extends EventTarget implements BenchLike {
    * Whether to subtract an estimated timestamp provider call overhead from
    * each raw latency sample.
    *
-   * Incompatible with `concurrency: 'task'`; the constraint is enforced
-   * at construction and at the start of {@link Bench.run}.
+   * Incompatible with `concurrency: 'task'`. Enforced at construction and
+   * re-checked at the start of {@link Bench.run} to guard against untyped
+   * (JS-side) mutation of the `readonly` `concurrency` field after
+   * construction.
    * @default false
    */
   readonly subtractTimerOverhead: boolean

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -24,6 +24,7 @@ import { BenchEvent } from './event'
 import { Task } from './task'
 import {
   assert,
+  calibrateTimerOverhead,
   defaultConvertTaskResultForConsoleTable,
   getTimestampProvider,
   runtime,
@@ -96,6 +97,13 @@ export class Bench extends EventTarget implements BenchLike {
   readonly signal?: AbortSignal
 
   /**
+   * Whether to subtract an estimated timestamp provider call overhead from
+   * each raw latency sample.
+   * @default false
+   */
+  readonly subtractTimerOverhead: boolean
+
+  /**
    * A teardown function that runs after each task execution.
    */
   readonly teardown: (
@@ -119,6 +127,15 @@ export class Bench extends EventTarget implements BenchLike {
    * The amount of time to run each task.
    */
   readonly time: number
+
+  /**
+   * The estimated cost of one timestamp provider call in milliseconds.
+   *
+   * `undefined` when {@link subtractTimerOverhead} is `false`.
+   * Otherwise calibrated once at construction time via
+   * {@link calibrateTimerOverhead}.
+   */
+  readonly timerOverhead: number | undefined
 
   /**
    * A timestamp provider and its related functions.
@@ -195,6 +212,10 @@ export class Bench extends EventTarget implements BenchLike {
     this.throws = restOptions.throws ?? false
     this.signal = restOptions.signal
     this.retainSamples = restOptions.retainSamples === true
+    this.subtractTimerOverhead = restOptions.subtractTimerOverhead === true
+    this.timerOverhead = this.subtractTimerOverhead
+      ? calibrateTimerOverhead(this.timestampProvider)
+      : undefined
 
     if (this.signal) {
       this.signal.addEventListener(

--- a/src/event.ts
+++ b/src/event.ts
@@ -4,6 +4,7 @@ import type {
   BenchEventsOptionalTask,
   BenchEventsWithError,
   BenchEventsWithTask,
+  TimerSaturationReason,
 } from './types'
 
 /**
@@ -25,6 +26,20 @@ class BenchEvent<
   }
 
   /**
+   * The reason a `'warning'` event was dispatched.
+   * @returns The {@link TimerSaturationReason} for `'warning'` events;
+   *   `undefined` for every other event type and for `'warning'` events
+   *   dispatched without a reason
+   */
+  get reason (): K extends 'warning'
+    ? TimerSaturationReason | undefined
+    : undefined {
+    return this.#reason as K extends 'warning'
+      ? TimerSaturationReason | undefined
+      : undefined
+  }
+
+  /**
    * The task associated with the event.
    * @returns The task if the event type is one that includes a task; otherwise, undefined
    */
@@ -41,15 +56,25 @@ class BenchEvent<
   }
 
   #error?: Error
+  #reason?: TimerSaturationReason
   #task?: Task
 
+  constructor (type: 'warning', task: Task, reason?: TimerSaturationReason)
   constructor (type: BenchEventsWithError, task: Task, error: Error)
   constructor (type: BenchEventsWithTask, task: Task)
   constructor (type: BenchEventsOptionalTask, task?: Task)
-  constructor (type: BenchEvents, task?: Task, error?: Error) {
+  constructor (
+    type: BenchEvents,
+    task?: Task,
+    errorOrReason?: Error | TimerSaturationReason
+  ) {
     super(type)
     this.#task = task
-    this.#error = error
+    if (typeof errorOrReason === 'string') {
+      this.#reason = errorOrReason
+    } else {
+      this.#error = errorOrReason
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export type {
   TaskResultStarted,
   TaskResultTimestampProviderInfo,
   TaskResultWithStatistics,
+  TimerSaturationReason,
   TimestampFn,
   TimestampFns,
   TimestampProvider,
@@ -40,7 +41,6 @@ export type {
 export type {
   CalibrateTimerOverheadOptions,
   TimerOverheadEstimatorKind,
-  TimerSaturationReason,
 } from './utils'
 export {
   calibrateTimerOverhead,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,8 +49,10 @@ export {
   estimateResolution,
   formatNumber,
   hrtimeNow,
+  hrtimeNowTimestampProvider,
   medianAbsoluteDeviation,
   mToNs,
   performanceNow as now,
   nToMs,
+  performanceNowTimestampProvider,
 } from './utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,4 +37,15 @@ export type {
   TimestampProvider,
   TimestampValue,
 } from './types'
-export { formatNumber, hrtimeNow, performanceNow as now, nToMs } from './utils'
+export type {
+  CalibrateTimerOverheadOptions,
+  TimerOverheadEstimator,
+} from './utils'
+export {
+  calibrateTimerOverhead,
+  estimateResolution,
+  formatNumber,
+  hrtimeNow,
+  performanceNow as now,
+  nToMs,
+} from './utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export type {
 } from './utils'
 export {
   calibrateTimerOverhead,
+  detectTimerSaturation,
   estimateResolution,
   formatNumber,
   hrtimeNow,

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,14 +39,17 @@ export type {
 } from './types'
 export type {
   CalibrateTimerOverheadOptions,
-  TimerOverheadEstimator,
+  TimerOverheadEstimatorKind,
+  TimerSaturationReason,
 } from './utils'
 export {
   calibrateTimerOverhead,
+  classifyTimerSaturation,
   detectTimerSaturation,
   estimateResolution,
   formatNumber,
   hrtimeNow,
+  medianAbsoluteDeviation,
   performanceNow as now,
   nToMs,
 } from './utils'

--- a/src/task.ts
+++ b/src/task.ts
@@ -660,7 +660,7 @@ export class Task extends EventTarget {
       // prevents a constant user value from being reported as the timer grain
       // or triggering a spurious low-distinct-count warning.
       let saturationReason: TimerSaturationReason | undefined
-      if (measuredOnly === latencySamples) {
+      if (!hasAnyOverridden) {
         this.#detectedResolution = estimateResolution(latencySamples)
         saturationReason = classifyTimerSaturation(
           latencySamples,

--- a/src/task.ts
+++ b/src/task.ts
@@ -15,16 +15,18 @@ import type {
   TimestampProvider,
   TimestampValue,
 } from './types'
+import type { TimerSaturationReason } from './types'
 
 import { BenchEvent } from './event'
 import {
   assert,
+  classifyTimerSaturation,
   computeStatistics,
-  detectTimerSaturation,
   estimateResolution,
   isFnAsyncResource,
   isPromiseLike,
   isValidSamples,
+  medianAbsoluteDeviation,
   sortSamples,
   toError,
   withConcurrency,
@@ -75,9 +77,11 @@ export class Task extends EventTarget {
   /**
    * The estimated effective timer resolution observed during the last run,
    * computed as the smallest strictly positive latency sample that appears
-   * at least twice in the sample set.
-   * @returns The resolution in milliseconds, or `undefined` when no run has
-   *   produced a strictly positive sample
+   * at least twice among the timer-measured samples (samples supplied via
+   * `overriddenDuration` are excluded).
+   * @returns The resolution in milliseconds, or `undefined` when no
+   *   timer-measured strictly positive sample was observed (e.g. every
+   *   sample was supplied via `overriddenDuration`)
    */
   get detectedResolution (): number | undefined {
     return this.#detectedResolution
@@ -368,8 +372,7 @@ export class Task extends EventTarget {
 
       let totalTime = 0 // ms
       const samples: number[] = []
-      const isOverridden: boolean[] | undefined =
-        this.#bench.timerOverhead !== undefined ? [] : undefined
+      const isOverridden: boolean[] = []
 
       const benchmarkTask = async () => {
         if (this.#aborted) {
@@ -385,7 +388,7 @@ export class Task extends EventTarget {
             : this.#measureSync()
 
           samples.push(taskTime)
-          isOverridden?.push(overridden)
+          isOverridden.push(overridden)
           totalTime += taskTime
         } finally {
           if (this.#fnOpts.afterEach != null) {
@@ -448,8 +451,7 @@ export class Task extends EventTarget {
 
       let totalTime = 0
       const samples: number[] = []
-      const isOverridden: boolean[] | undefined =
-        this.#bench.timerOverhead !== undefined ? [] : undefined
+      const isOverridden: boolean[] = []
 
       const benchmarkTask = () => {
         if (this.#aborted) {
@@ -467,7 +469,7 @@ export class Task extends EventTarget {
           const { overridden, taskTime } = this.#measureSync()
 
           samples.push(taskTime)
-          isOverridden?.push(overridden)
+          isOverridden.push(overridden)
           totalTime += taskTime
         } finally {
           if (this.#fnOpts.afterEach) {
@@ -592,14 +594,15 @@ export class Task extends EventTarget {
    *    matches `isOverridden[i]` because no sort has been performed yet).
    *    Samples whose duration was supplied via `overriddenDuration` are skipped.
    * 2. Build a measured-only view (excluding `overriddenDuration` samples) used
-   *    for timer-saturation detection. Constant `overriddenDuration` values would
-   *    otherwise trigger a spurious low-distinct-count warning.
-   * 3. Sort the working array for the final statistics and diagnostics.
-   * 4. Compute `detectedResolution` from the sorted samples.
+   *    for both `detectedResolution` and timer-saturation detection. Constant
+   *    `overriddenDuration` values would otherwise be reported as the timer
+   *    grain or trigger a spurious low-distinct-count warning.
+   * 3. Compute `detectedResolution` from the measured-only subset.
+   * 4. Sort the working array for the final statistics.
    * 5. Compute the final statistics on the (possibly corrected) sorted samples.
-   * 6. Run timer-saturation detection on the measured-only subset.
-   * 7. Dispatch `'cycle'` and `'complete'` events; dispatch `'warning'` if
-   *    timer saturation was detected.
+   * 6. Classify timer saturation on the measured-only subset.
+   * 7. Dispatch `'cycle'` and `'complete'` events; dispatch `'warning'` (carrying
+   *    the {@link TimerSaturationReason}) if a saturation criterion fired.
    * @param options - An object containing the run results
    * @param options.error - The error that occurred during the run, if any
    * @param options.isOverridden - Parallel boolean array (collection order) indicating
@@ -641,11 +644,16 @@ export class Task extends EventTarget {
         ? latencySamples.filter((_, i) => isOverridden![i] !== true)
         : latencySamples
 
-      // Phase 3 — Single sort of the working array.
-      sortSamples(latencySamples)
+      // Phase 3 — Resolution diagnostic on the measured-only subset.
+      // Excluding `overriddenDuration` samples prevents a constant user
+      // value from being reported as the timer grain. `estimateResolution`
+      // is sort-invariant, so it can run before the working-array sort.
+      this.#detectedResolution = isValidSamples(measuredOnly)
+        ? estimateResolution(measuredOnly)
+        : undefined
 
-      // Phase 4 — Resolution diagnostic on sorted samples.
-      this.#detectedResolution = estimateResolution(latencySamples)
+      // Phase 4 — Single sort of the working array.
+      sortSamples(latencySamples)
 
       // Phase 5 — Final statistics on (possibly corrected) sorted samples.
       const latencyStatistics = computeStatistics(
@@ -653,14 +661,19 @@ export class Task extends EventTarget {
         this.#retainSamples
       )
 
-      // Phase 6 — Saturation detection on measured-only samples.
-      let saturated = false
+      // Phase 6 — Saturation classification on the measured-only subset.
+      let saturationReason: TimerSaturationReason | undefined
       if (measuredOnly === latencySamples) {
-        saturated = detectTimerSaturation(latencySamples, latencyStatistics.mad)
+        saturationReason = classifyTimerSaturation(
+          latencySamples,
+          latencyStatistics.mad
+        )
       } else if (isValidSamples(measuredOnly)) {
         sortSamples(measuredOnly)
-        const measuredStats = computeStatistics(measuredOnly, false)
-        saturated = detectTimerSaturation(measuredOnly, measuredStats.mad)
+        saturationReason = classifyTimerSaturation(
+          measuredOnly,
+          medianAbsoluteDeviation(measuredOnly)
+        )
       }
 
       const latencyStatisticsMean = latencyStatistics.mean
@@ -695,8 +708,8 @@ export class Task extends EventTarget {
       }
       /* eslint-enable perfectionist/sort-objects */
 
-      if (saturated) {
-        const warningEv = new BenchEvent('warning', this)
+      if (saturationReason !== undefined) {
+        const warningEv = new BenchEvent('warning', this, saturationReason)
         this.dispatchEvent(warningEv)
         this.#bench.dispatchEvent(warningEv)
       }

--- a/src/task.ts
+++ b/src/task.ts
@@ -20,6 +20,8 @@ import { BenchEvent } from './event'
 import {
   assert,
   computeStatistics,
+  detectTimerSaturation,
+  estimateResolution,
   isFnAsyncResource,
   isPromiseLike,
   isValidSamples,
@@ -71,6 +73,17 @@ export class Task extends EventTarget {
   ) => void
 
   /**
+   * The estimated effective timer resolution observed during the last run,
+   * computed as the smallest strictly positive latency sample that appears
+   * at least twice in the sample set.
+   * @returns The resolution in milliseconds, or `undefined` when no run has
+   *   produced a strictly positive sample
+   */
+  get detectedResolution (): number | undefined {
+    return this.#detectedResolution
+  }
+
+  /**
    * The name of the task.
    * @returns The task name as a string
    */
@@ -115,6 +128,11 @@ export class Task extends EventTarget {
    * The Bench instance reference
    */
   readonly #bench: BenchLike
+
+  /**
+   * The estimated effective timer resolution from the last run.
+   */
+  #detectedResolution: number | undefined = undefined
 
   /**
    * The task function
@@ -217,6 +235,7 @@ export class Task extends EventTarget {
    */
   reset (emit = true): void {
     this.#runs = 0
+    this.#detectedResolution = undefined
     this.#result = this.#aborted ? abortedTaskResult : notStartedTaskResult
 
     if (emit) this.dispatchEvent(new BenchEvent('reset', this))
@@ -233,14 +252,14 @@ export class Task extends EventTarget {
     this.#result = { state: 'started' }
     this.dispatchEvent(new BenchEvent('start', this))
     await this.#bench.setup(this, 'run')
-    const { error, samples: latencySamples } = await this.#benchmark(
-      'run',
-      this.#bench.time,
-      this.#bench.iterations
-    )
+    const {
+      error,
+      isOverridden,
+      samples: latencySamples,
+    } = await this.#benchmark('run', this.#bench.time, this.#bench.iterations)
     await this.#bench.teardown(this, 'run')
 
-    this.#processRunResult({ error, latencySamples })
+    this.#processRunResult({ error, isOverridden, latencySamples })
 
     return this
   }
@@ -267,11 +286,11 @@ export class Task extends EventTarget {
       '`setup` function must be sync when using `runSync()`'
     )
 
-    const { error, samples: latencySamples } = this.#benchmarkSync(
-      'run',
-      this.#bench.time,
-      this.#bench.iterations
-    )
+    const {
+      error,
+      isOverridden,
+      samples: latencySamples,
+    } = this.#benchmarkSync('run', this.#bench.time, this.#bench.iterations)
 
     const teardownResult = this.#bench.teardown(this, 'run')
     assert(
@@ -279,7 +298,7 @@ export class Task extends EventTarget {
       '`teardown` function must be sync when using `runSync()`'
     )
 
-    this.#processRunResult({ error, latencySamples })
+    this.#processRunResult({ error, isOverridden, latencySamples })
 
     return this
   }
@@ -339,7 +358,8 @@ export class Task extends EventTarget {
     time: number,
     iterations: number
   ): Promise<
-    { error: Error; samples?: never } | { error?: never; samples?: Samples }
+    | { error: Error; isOverridden?: never; samples?: never }
+    | { error?: never; isOverridden?: boolean[]; samples?: Samples }
   > {
     try {
       if (this.#fnOpts.beforeAll) {
@@ -348,6 +368,8 @@ export class Task extends EventTarget {
 
       let totalTime = 0 // ms
       const samples: number[] = []
+      const isOverridden: boolean[] | undefined =
+        this.#bench.timerOverhead !== undefined ? [] : undefined
 
       const benchmarkTask = async () => {
         if (this.#aborted) {
@@ -358,11 +380,12 @@ export class Task extends EventTarget {
             await this.#fnOpts.beforeEach.call(this, mode)
           }
 
-          const taskTime = this.#async
+          const { overridden, taskTime } = this.#async
             ? await this.#measure()
             : this.#measureSync()
 
           samples.push(taskTime)
+          isOverridden?.push(overridden)
           totalTime += taskTime
         } finally {
           if (this.#fnOpts.afterEach != null) {
@@ -395,7 +418,7 @@ export class Task extends EventTarget {
         await this.#fnOpts.afterAll.call(this, mode)
       }
 
-      return isValidSamples(samples) ? { samples } : {}
+      return isValidSamples(samples) ? { isOverridden, samples } : {}
     } catch (error) {
       return { error: toError(error) }
     }
@@ -411,7 +434,9 @@ export class Task extends EventTarget {
     mode: 'run' | 'warmup',
     time: number,
     iterations: number
-  ): { error: Error; samples?: never } | { error?: never; samples?: Samples } {
+  ):
+    | { error: Error; isOverridden?: never; samples?: never }
+    | { error?: never; isOverridden?: boolean[]; samples?: Samples } {
     try {
       if (this.#fnOpts.beforeAll) {
         const beforeAllResult = this.#fnOpts.beforeAll.call(this, mode)
@@ -423,6 +448,8 @@ export class Task extends EventTarget {
 
       let totalTime = 0
       const samples: number[] = []
+      const isOverridden: boolean[] | undefined =
+        this.#bench.timerOverhead !== undefined ? [] : undefined
 
       const benchmarkTask = () => {
         if (this.#aborted) {
@@ -437,9 +464,10 @@ export class Task extends EventTarget {
             )
           }
 
-          const taskTime = this.#measureSync()
+          const { overridden, taskTime } = this.#measureSync()
 
           samples.push(taskTime)
+          isOverridden?.push(overridden)
           totalTime += taskTime
         } finally {
           if (this.#fnOpts.afterEach) {
@@ -467,7 +495,7 @@ export class Task extends EventTarget {
           '`afterAll` function must be sync when using `runSync()`'
         )
       }
-      return isValidSamples(samples) ? { samples } : {}
+      return isValidSamples(samples) ? { isOverridden, samples } : {}
     } catch (error) {
       return { error: toError(error) }
     }
@@ -475,9 +503,10 @@ export class Task extends EventTarget {
 
   /**
    * Measures a single execution of the task function asynchronously.
-   * @returns The measured execution time
+   * @returns The measured execution time and whether it was supplied by the
+   *   task function via `overriddenDuration`
    */
-  async #measure (): Promise<number> {
+  async #measure (): Promise<{ overridden: boolean; taskTime: number }> {
     const taskStart = this.#timestampFn() as unknown as number
     // eslint-disable-next-line no-useless-call
     const fnResult = await this.#fn.call(this)
@@ -487,16 +516,17 @@ export class Task extends EventTarget {
 
     const overriddenDuration = getOverriddenDurationFromFnResult(fnResult)
     if (overriddenDuration !== undefined) {
-      return overriddenDuration
+      return { overridden: true, taskTime: overriddenDuration }
     }
-    return taskTime
+    return { overridden: false, taskTime }
   }
 
   /**
    * Measures a single execution of the task function synchronously.
-   * @returns The measured execution time
+   * @returns The measured execution time and whether it was supplied by the
+   *   task function via `overriddenDuration`
    */
-  #measureSync (): number {
+  #measureSync (): { overridden: boolean; taskTime: number } {
     const taskStart = this.#timestampFn() as unknown as number
     // eslint-disable-next-line no-useless-call
     const fnResult = this.#fn.call(this)
@@ -510,9 +540,9 @@ export class Task extends EventTarget {
     )
     const overriddenDuration = getOverriddenDurationFromFnResult(fnResult)
     if (overriddenDuration !== undefined) {
-      return overriddenDuration
+      return { overridden: true, taskTime: overriddenDuration }
     }
-    return taskTime
+    return { overridden: false, taskTime }
   }
 
   /**
@@ -555,15 +585,35 @@ export class Task extends EventTarget {
   /**
    * Processes the result of a benchmark run and updates the task result.
    * Calculates statistics from the collected samples and dispatches appropriate events.
-   * @param options - An object containing the error and latency samples from the run
+   *
+   * Ordering:
+   * 1. Sort raw samples in place.
+   * 2. Compute the raw timer-resolution diagnostic ({@link estimateResolution}).
+   * 3. If overhead correction is enabled: compute raw statistics for an
+   *    accurate `mad`, evaluate timer-saturation against the **raw** sample
+   *    set, then subtract the calibrated overhead from each sample whose
+   *    duration was measured by the timer (skipping samples supplied via
+   *    `overriddenDuration`). Re-sort only when overridden samples were
+   *    skipped, since correction otherwise preserves the ascending order.
+   * 4. Compute the final (possibly corrected) statistics.
+   * 5. When no correction was applied, evaluate timer-saturation against the
+   *    final samples (raw == final in this case).
+   * 6. Dispatch `'cycle'` and `'complete'` events; dispatch `'warning'` if
+   *    timer saturation was detected.
+   * @param options - An object containing the run results
    * @param options.error - The error that occurred during the run, if any
+   * @param options.isOverridden - Parallel boolean array indicating which
+   *   samples were supplied by the task function via `overriddenDuration`,
+   *   or `undefined` when overhead correction is disabled
    * @param options.latencySamples - The array of latency samples collected during the run
    */
   #processRunResult ({
     error,
+    isOverridden,
     latencySamples,
   }: {
     error?: Error
+    isOverridden?: boolean[]
     latencySamples?: number[]
   }): void {
     if (isValidSamples(latencySamples)) {
@@ -571,10 +621,37 @@ export class Task extends EventTarget {
 
       sortSamples(latencySamples)
 
+      this.#detectedResolution = estimateResolution(latencySamples)
+
+      const overhead = this.#bench.timerOverhead
+      const hasOverhead = overhead !== undefined && overhead > 0
+      let saturated = false
+
+      if (hasOverhead) {
+        const rawStatistics = computeStatistics(latencySamples, false)
+        saturated = detectTimerSaturation(latencySamples, rawStatistics.mad)
+
+        let needsResort = false
+        for (let i = 0; i < latencySamples.length; i++) {
+          if (isOverridden?.[i] === true) {
+            needsResort = true
+          } else {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            latencySamples[i] = Math.max(0, latencySamples[i]! - overhead)
+          }
+        }
+        if (needsResort) sortSamples(latencySamples)
+      }
+
       const latencyStatistics = computeStatistics(
         latencySamples,
         this.#retainSamples
       )
+
+      if (!hasOverhead) {
+        saturated = detectTimerSaturation(latencySamples, latencyStatistics.mad)
+      }
+
       const latencyStatisticsMean = latencyStatistics.mean
 
       let totalTime = 0
@@ -606,6 +683,12 @@ export class Task extends EventTarget {
         totalTime,
       }
       /* eslint-enable perfectionist/sort-objects */
+
+      if (saturated) {
+        const warningEv = new BenchEvent('warning', this)
+        this.dispatchEvent(warningEv)
+        this.#bench.dispatchEvent(warningEv)
+      }
     } else if (this.#aborted) {
       // If aborted with no samples, still set the aborted flag
       this.#result = abortedTaskResult

--- a/src/task.ts
+++ b/src/task.ts
@@ -596,8 +596,8 @@ export class Task extends EventTarget {
    *
    * Ordering:
    * 1. Apply overhead correction in-place on the collection-order sample array
-   *    (alignment with `isOverridden` preserved — `latencySamples[i]` still
-   *    matches `isOverridden[i]` because no sort has been performed yet).
+   *    (alignment with `overriddenIndices` preserved — index `i` still refers
+   *    to the same sample because no sort has been performed yet).
    *    Samples whose duration was supplied via `overriddenDuration` are skipped.
    * 2. Build a measured-only view (excluding `overriddenDuration` samples) used
    *    for both `detectedResolution` and timer-saturation detection. Constant

--- a/src/task.ts
+++ b/src/task.ts
@@ -260,12 +260,12 @@ export class Task extends EventTarget {
     await this.#bench.setup(this, 'run')
     const {
       error,
-      isOverridden,
+      overriddenIndices,
       samples: latencySamples,
     } = await this.#benchmark('run', this.#bench.time, this.#bench.iterations)
     await this.#bench.teardown(this, 'run')
 
-    this.#processRunResult({ error, isOverridden, latencySamples })
+    this.#processRunResult({ error, latencySamples, overriddenIndices })
 
     return this
   }
@@ -294,7 +294,7 @@ export class Task extends EventTarget {
 
     const {
       error,
-      isOverridden,
+      overriddenIndices,
       samples: latencySamples,
     } = this.#benchmarkSync('run', this.#bench.time, this.#bench.iterations)
 
@@ -304,7 +304,7 @@ export class Task extends EventTarget {
       '`teardown` function must be sync when using `runSync()`'
     )
 
-    this.#processRunResult({ error, isOverridden, latencySamples })
+    this.#processRunResult({ error, latencySamples, overriddenIndices })
 
     return this
   }
@@ -364,8 +364,8 @@ export class Task extends EventTarget {
     time: number,
     iterations: number
   ): Promise<
-    | { error: Error; isOverridden?: never; samples?: never }
-    | { error?: never; isOverridden?: boolean[]; samples?: Samples }
+    | { error: Error; overriddenIndices?: never; samples?: never }
+    | { error?: never; overriddenIndices?: Set<number>; samples?: Samples }
   > {
     try {
       if (this.#fnOpts.beforeAll) {
@@ -374,7 +374,7 @@ export class Task extends EventTarget {
 
       let totalTime = 0 // ms
       const samples: number[] = []
-      const isOverridden: boolean[] = []
+      const overriddenIndices = new Set<number>()
 
       const benchmarkTask = async () => {
         if (this.#aborted) {
@@ -389,8 +389,8 @@ export class Task extends EventTarget {
             ? await this.#measure()
             : this.#measureSync()
 
-          samples.push(taskTime)
-          isOverridden.push(overridden)
+          const idx = samples.push(taskTime) - 1
+          if (overridden) overriddenIndices.add(idx)
           totalTime += taskTime
         } finally {
           if (this.#fnOpts.afterEach != null) {
@@ -423,7 +423,7 @@ export class Task extends EventTarget {
         await this.#fnOpts.afterAll.call(this, mode)
       }
 
-      return isValidSamples(samples) ? { isOverridden, samples } : {}
+      return isValidSamples(samples) ? { overriddenIndices, samples } : {}
     } catch (error) {
       return { error: toError(error) }
     }
@@ -440,8 +440,8 @@ export class Task extends EventTarget {
     time: number,
     iterations: number
   ):
-    | { error: Error; isOverridden?: never; samples?: never }
-    | { error?: never; isOverridden?: boolean[]; samples?: Samples } {
+    | { error: Error; overriddenIndices?: never; samples?: never }
+    | { error?: never; overriddenIndices?: Set<number>; samples?: Samples } {
     try {
       if (this.#fnOpts.beforeAll) {
         const beforeAllResult = this.#fnOpts.beforeAll.call(this, mode)
@@ -453,7 +453,7 @@ export class Task extends EventTarget {
 
       let totalTime = 0
       const samples: number[] = []
-      const isOverridden: boolean[] = []
+      const overriddenIndices = new Set<number>()
 
       const benchmarkTask = () => {
         if (this.#aborted) {
@@ -470,8 +470,8 @@ export class Task extends EventTarget {
 
           const { overridden, taskTime } = this.#measureSync()
 
-          samples.push(taskTime)
-          isOverridden.push(overridden)
+          const idx = samples.push(taskTime) - 1
+          if (overridden) overriddenIndices.add(idx)
           totalTime += taskTime
         } finally {
           if (this.#fnOpts.afterEach) {
@@ -499,7 +499,7 @@ export class Task extends EventTarget {
           '`afterAll` function must be sync when using `runSync()`'
         )
       }
-      return isValidSamples(samples) ? { isOverridden, samples } : {}
+      return isValidSamples(samples) ? { overriddenIndices, samples } : {}
     } catch (error) {
       return { error: toError(error) }
     }
@@ -607,19 +607,19 @@ export class Task extends EventTarget {
    *    saturation criterion fired, then `'cycle'` and `'complete'`.
    * @param options - An object containing the run results
    * @param options.error - The error that occurred during the run, if any
-   * @param options.isOverridden - Parallel boolean array (collection order) indicating
-   *   which samples were supplied by the task function via `overriddenDuration`,
-   *   or `undefined` on the error / no-valid-samples path
    * @param options.latencySamples - The array of latency samples collected during the run
+   * @param options.overriddenIndices - Set of collection-order indices whose
+   *   samples were supplied by the task function via `overriddenDuration`,
+   *   or `undefined` on the error / no-valid-samples path
    */
   #processRunResult ({
     error,
-    isOverridden,
     latencySamples,
+    overriddenIndices,
   }: {
     error?: Error
-    isOverridden?: boolean[]
     latencySamples?: number[]
+    overriddenIndices?: Set<number>
   }): void {
     if (isValidSamples(latencySamples)) {
       this.#runs = latencySamples.length
@@ -627,22 +627,23 @@ export class Task extends EventTarget {
       const overhead = this.#bench.timerOverhead
       const hasOverhead = overhead !== undefined && overhead > 0
 
-      // Phase 1 — Subtract overhead while isOverridden[i] is still aligned with
-      // latencySamples[i] (both in collection order, pre-sort).
+      // Phase 1 — Subtract overhead while overriddenIndices is still aligned
+      // with latencySamples[i] (collection order, pre-sort).
       if (hasOverhead) {
         for (let i = 0; i < latencySamples.length; i++) {
-          if (isOverridden?.[i] !== true) {
+          if (!overriddenIndices?.has(i)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             latencySamples[i] = Math.max(0, latencySamples[i]! - overhead)
           }
         }
       }
 
-      // Phase 2 — Capture measured-only samples (alignment with isOverridden
-      // is still valid since the array has not been sorted yet).
-      const hasAnyOverridden = isOverridden?.some(v => v) ?? false
+      // Phase 2 — Capture measured-only samples (alignment with
+      // overriddenIndices is still valid since the array has not been sorted
+      // yet).
+      const hasAnyOverridden = (overriddenIndices?.size ?? 0) > 0
       const measuredOnly: number[] = hasAnyOverridden
-        ? latencySamples.filter((_, i) => isOverridden?.[i] !== true)
+        ? latencySamples.filter((_, i) => !overriddenIndices?.has(i))
         : latencySamples
 
       // Phase 3 — Single sort of the working array.

--- a/src/task.ts
+++ b/src/task.ts
@@ -587,23 +587,23 @@ export class Task extends EventTarget {
    * Calculates statistics from the collected samples and dispatches appropriate events.
    *
    * Ordering:
-   * 1. Sort raw samples in place.
-   * 2. Compute the raw timer-resolution diagnostic ({@link estimateResolution}).
-   * 3. If overhead correction is enabled: compute raw statistics for an
-   *    accurate `mad`, evaluate timer-saturation against the **raw** sample
-   *    set, then subtract the calibrated overhead from each sample whose
-   *    duration was measured by the timer (skipping samples supplied via
-   *    `overriddenDuration`). Re-sort only when overridden samples were
-   *    skipped, since correction otherwise preserves the ascending order.
-   * 4. Compute the final (possibly corrected) statistics.
-   * 5. When no correction was applied, evaluate timer-saturation against the
-   *    final samples (raw == final in this case).
-   * 6. Dispatch `'cycle'` and `'complete'` events; dispatch `'warning'` if
+   * 1. Apply overhead correction in-place on the collection-order sample array
+   *    (alignment with `isOverridden` preserved — `latencySamples[i]` still
+   *    matches `isOverridden[i]` because no sort has been performed yet).
+   *    Samples whose duration was supplied via `overriddenDuration` are skipped.
+   * 2. Build a measured-only view (excluding `overriddenDuration` samples) used
+   *    for timer-saturation detection. Constant `overriddenDuration` values would
+   *    otherwise trigger a spurious low-distinct-count warning.
+   * 3. Sort the working array for the final statistics and diagnostics.
+   * 4. Compute `detectedResolution` from the sorted samples.
+   * 5. Compute the final statistics on the (possibly corrected) sorted samples.
+   * 6. Run timer-saturation detection on the measured-only subset.
+   * 7. Dispatch `'cycle'` and `'complete'` events; dispatch `'warning'` if
    *    timer saturation was detected.
    * @param options - An object containing the run results
    * @param options.error - The error that occurred during the run, if any
-   * @param options.isOverridden - Parallel boolean array indicating which
-   *   samples were supplied by the task function via `overriddenDuration`,
+   * @param options.isOverridden - Parallel boolean array (collection order) indicating
+   *   which samples were supplied by the task function via `overriddenDuration`,
    *   or `undefined` when overhead correction is disabled
    * @param options.latencySamples - The array of latency samples collected during the run
    */
@@ -619,37 +619,48 @@ export class Task extends EventTarget {
     if (isValidSamples(latencySamples)) {
       this.#runs = latencySamples.length
 
-      sortSamples(latencySamples)
-
-      this.#detectedResolution = estimateResolution(latencySamples)
-
       const overhead = this.#bench.timerOverhead
       const hasOverhead = overhead !== undefined && overhead > 0
-      let saturated = false
 
+      // Phase 1 — Subtract overhead while isOverridden[i] is still aligned with
+      // latencySamples[i] (both in collection order, pre-sort).
       if (hasOverhead) {
-        const rawStatistics = computeStatistics(latencySamples, false)
-        saturated = detectTimerSaturation(latencySamples, rawStatistics.mad)
-
-        let needsResort = false
         for (let i = 0; i < latencySamples.length; i++) {
-          if (isOverridden?.[i] === true) {
-            needsResort = true
-          } else {
+          if (isOverridden?.[i] !== true) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             latencySamples[i] = Math.max(0, latencySamples[i]! - overhead)
           }
         }
-        if (needsResort) sortSamples(latencySamples)
       }
 
+      // Phase 2 — Capture measured-only samples (alignment with isOverridden
+      // is still valid since the array has not been sorted yet).
+      const hasAnyOverridden = isOverridden?.some(v => v) ?? false
+      const measuredOnly: number[] = hasAnyOverridden
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ? latencySamples.filter((_, i) => isOverridden![i] !== true)
+        : latencySamples
+
+      // Phase 3 — Single sort of the working array.
+      sortSamples(latencySamples)
+
+      // Phase 4 — Resolution diagnostic on sorted samples.
+      this.#detectedResolution = estimateResolution(latencySamples)
+
+      // Phase 5 — Final statistics on (possibly corrected) sorted samples.
       const latencyStatistics = computeStatistics(
         latencySamples,
         this.#retainSamples
       )
 
-      if (!hasOverhead) {
+      // Phase 6 — Saturation detection on measured-only samples.
+      let saturated = false
+      if (measuredOnly === latencySamples) {
         saturated = detectTimerSaturation(latencySamples, latencyStatistics.mad)
+      } else if (isValidSamples(measuredOnly)) {
+        sortSamples(measuredOnly)
+        const measuredStats = computeStatistics(measuredOnly, false)
+        saturated = detectTimerSaturation(measuredOnly, measuredStats.mad)
       }
 
       const latencyStatisticsMean = latencyStatistics.mean

--- a/src/task.ts
+++ b/src/task.ts
@@ -76,9 +76,11 @@ export class Task extends EventTarget {
 
   /**
    * The estimated effective timer resolution observed during the last run,
-   * computed as the smallest strictly positive latency sample that appears
-   * at least twice among the timer-measured samples (samples supplied via
-   * `overriddenDuration` are excluded).
+   * computed as the smallest strictly positive latency sample that repeats
+   * among the timer-measured samples, or the smallest strictly positive
+   * sample when none repeats (samples supplied via `overriddenDuration` are
+   * excluded). When `subtractTimerOverhead` is enabled the value is derived
+   * from the overhead-corrected samples rather than the raw timer grain.
    * @returns The resolution in milliseconds, or `undefined` when no
    *   timer-measured strictly positive sample was observed (e.g. every
    *   sample was supplied via `overriddenDuration`)
@@ -597,12 +599,12 @@ export class Task extends EventTarget {
    *    for both `detectedResolution` and timer-saturation detection. Constant
    *    `overriddenDuration` values would otherwise be reported as the timer
    *    grain or trigger a spurious low-distinct-count warning.
-   * 3. Compute `detectedResolution` from the measured-only subset.
-   * 4. Sort the working array for the final statistics.
-   * 5. Compute the final statistics on the (possibly corrected) sorted samples.
-   * 6. Classify timer saturation on the measured-only subset.
-   * 7. Dispatch `'cycle'` and `'complete'` events; dispatch `'warning'` (carrying
-   *    the {@link TimerSaturationReason}) if a saturation criterion fired.
+   * 3. Sort the working array for the final statistics.
+   * 4. Compute the final statistics on the (possibly corrected) sorted samples.
+   * 5. Compute `detectedResolution` and classify timer saturation on the
+   *    (sorted) measured-only subset.
+   * 6. Dispatch `'warning'` (carrying the {@link TimerSaturationReason}) if a
+   *    saturation criterion fired, then `'cycle'` and `'complete'`.
    * @param options - An object containing the run results
    * @param options.error - The error that occurred during the run, if any
    * @param options.isOverridden - Parallel boolean array (collection order) indicating
@@ -644,36 +646,35 @@ export class Task extends EventTarget {
         ? latencySamples.filter((_, i) => isOverridden![i] !== true)
         : latencySamples
 
-      // Phase 3 — Resolution diagnostic on the measured-only subset.
-      // Excluding `overriddenDuration` samples prevents a constant user
-      // value from being reported as the timer grain. `estimateResolution`
-      // is sort-invariant, so it can run before the working-array sort.
-      this.#detectedResolution = isValidSamples(measuredOnly)
-        ? estimateResolution(measuredOnly)
-        : undefined
-
-      // Phase 4 — Single sort of the working array.
+      // Phase 3 — Single sort of the working array.
       sortSamples(latencySamples)
 
-      // Phase 5 — Final statistics on (possibly corrected) sorted samples.
+      // Phase 4 — Final statistics on (possibly corrected) sorted samples.
       const latencyStatistics = computeStatistics(
         latencySamples,
         this.#retainSamples
       )
 
-      // Phase 6 — Saturation classification on the measured-only subset.
+      // Phase 5 — Resolution diagnostic and saturation classification on the
+      // measured-only subset (sorted). Excluding `overriddenDuration` samples
+      // prevents a constant user value from being reported as the timer grain
+      // or triggering a spurious low-distinct-count warning.
       let saturationReason: TimerSaturationReason | undefined
       if (measuredOnly === latencySamples) {
+        this.#detectedResolution = estimateResolution(latencySamples)
         saturationReason = classifyTimerSaturation(
           latencySamples,
           latencyStatistics.mad
         )
       } else if (isValidSamples(measuredOnly)) {
         sortSamples(measuredOnly)
+        this.#detectedResolution = estimateResolution(measuredOnly)
         saturationReason = classifyTimerSaturation(
           measuredOnly,
           medianAbsoluteDeviation(measuredOnly)
         )
+      } else {
+        this.#detectedResolution = undefined
       }
 
       const latencyStatisticsMean = latencyStatistics.mean

--- a/src/task.ts
+++ b/src/task.ts
@@ -609,7 +609,7 @@ export class Task extends EventTarget {
    * @param options.error - The error that occurred during the run, if any
    * @param options.isOverridden - Parallel boolean array (collection order) indicating
    *   which samples were supplied by the task function via `overriddenDuration`,
-   *   or `undefined` when overhead correction is disabled
+   *   or `undefined` on the error / no-valid-samples path
    * @param options.latencySamples - The array of latency samples collected during the run
    */
   #processRunResult ({
@@ -642,8 +642,7 @@ export class Task extends EventTarget {
       // is still valid since the array has not been sorted yet).
       const hasAnyOverridden = isOverridden?.some(v => v) ?? false
       const measuredOnly: number[] = hasAnyOverridden
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        ? latencySamples.filter((_, i) => isOverridden![i] !== true)
+        ? latencySamples.filter((_, i) => isOverridden?.[i] !== true)
         : latencySamples
 
       // Phase 3 — Single sort of the working array.

--- a/src/task.ts
+++ b/src/task.ts
@@ -43,6 +43,15 @@ const hookNames = ['afterAll', 'beforeAll', 'beforeEach', 'afterEach'] as const
 const abortableStates = ['not-started', 'started'] as const
 
 /**
+ * Result of a single `#benchmark` / `#benchmarkSync` run: either an `error`,
+ * or the collected `samples` together with the `overriddenIndices` whose
+ * durations were supplied via `overriddenDuration` (mutually exclusive).
+ */
+type BenchmarkResult =
+  | { error: Error; overriddenIndices?: never; samples?: never }
+  | { error?: never; overriddenIndices?: Set<number>; samples?: Samples }
+
+/**
  * Default task result for tasks that have not yet started.
  */
 const notStartedTaskResult: TaskResult = { state: 'not-started' }
@@ -363,10 +372,7 @@ export class Task extends EventTarget {
     mode: 'run' | 'warmup',
     time: number,
     iterations: number
-  ): Promise<
-    | { error: Error; overriddenIndices?: never; samples?: never }
-    | { error?: never; overriddenIndices?: Set<number>; samples?: Samples }
-  > {
+  ): Promise<BenchmarkResult> {
     try {
       if (this.#fnOpts.beforeAll) {
         await this.#fnOpts.beforeAll.call(this, mode)
@@ -439,9 +445,7 @@ export class Task extends EventTarget {
     mode: 'run' | 'warmup',
     time: number,
     iterations: number
-  ):
-    | { error: Error; overriddenIndices?: never; samples?: never }
-    | { error?: never; overriddenIndices?: Set<number>; samples?: Samples } {
+  ): BenchmarkResult {
     try {
       if (this.#fnOpts.beforeAll) {
         const beforeAllResult = this.#fnOpts.beforeAll.call(this, mode)

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type BenchEvents =
   | 'reset' // when the reset method gets called
   | 'start' // when running the benchmarks gets started
   | 'warmup' // when the benchmarks start getting warmed up
+  | 'warning' // when timer saturation is detected for a task's latency samples
 
 /**
  * Bench events that may have an associated Task
@@ -41,7 +42,7 @@ export type BenchEventsWithError = Extract<BenchEvents, 'error'>
  */
 export type BenchEventsWithTask = Extract<
   BenchEvents,
-  'add' | 'cycle' | 'error' | 'remove'
+  'add' | 'cycle' | 'error' | 'remove' | 'warning'
 >
 
 /**
@@ -121,6 +122,11 @@ export interface BenchLike extends EventTarget {
    */
   time: number
   /**
+   * The estimated cost of one timestamp provider call in milliseconds, or
+   * `undefined` when timer overhead subtraction is disabled.
+   */
+  timerOverhead: number | undefined
+  /**
    * The timestamp provider used by the benchmark.
    */
   timestampProvider: TimestampProvider
@@ -182,6 +188,28 @@ export interface BenchOptions {
    * An AbortSignal for aborting the benchmark.
    */
   signal?: AbortSignal
+
+  /**
+   * Whether to subtract an estimated timestamp provider call overhead from
+   * each raw latency sample.
+   *
+   * Each sample is measured as `t1 - t0` around a single call to the task
+   * function, so every raw sample is inflated by approximately one
+   * timestamp provider call cost `C`. When this option is `true`, an
+   * estimate `Ĉ` is computed once at construction time via
+   * {@link calibrateTimerOverhead}, and `max(0, raw_sample - Ĉ)` is used
+   * instead. Only location statistics (mean, percentiles) are corrected;
+   * variance, standard deviation and relative margin of error are not, since
+   * subtracting a constant does not reduce dispersion.
+   *
+   * Samples returned by the task function via `overriddenDuration` are
+   * intentional user values and are never modified by the correction.
+   *
+   * On runtimes with a coarse timer (resolution >= 1 ms), the calibration
+   * returns `0` and this option becomes a no-op.
+   * @default false
+   */
+  subtractTimerOverhead?: boolean
 
   /**
    * Teardown function to run after each benchmark task (cycle).
@@ -403,6 +431,7 @@ export interface ResolvedBenchOptions extends BenchOptions {
   iterations: NonNullable<BenchOptions['iterations']>
   now: NonNullable<BenchOptions['now']>
   setup: NonNullable<BenchOptions['setup']>
+  subtractTimerOverhead: NonNullable<BenchOptions['subtractTimerOverhead']>
   teardown: NonNullable<BenchOptions['teardown']>
   throws: NonNullable<BenchOptions['throws']>
   time: NonNullable<BenchOptions['time']>
@@ -538,6 +567,7 @@ export type TaskEvents = Extract<
   | 'reset' // when the reset method gets called
   | 'start' // when running the task gets started
   | 'warmup' // when the task start getting warmed up
+  | 'warning' // when timer saturation is detected for the task's latency samples
 >
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -722,6 +722,20 @@ export interface TaskResultWithStatistics {
 }
 
 /**
+ * Reason a sample set is classified as timer-saturated.
+ *
+ * - `'zero-dominated'` — more than half of the samples are exactly zero.
+ * - `'low-distinct'` — distinct sample count is below
+ *   `max(3, min(10, ⌊n / 1000⌋))`.
+ * - `'zero-mad'` — median absolute deviation is zero with more than 100
+ *   samples.
+ */
+export type TimerSaturationReason =
+  | 'low-distinct'
+  | 'zero-dominated'
+  | 'zero-mad'
+
+/**
  * A timestamp function that returns either a number or bigint.
  */
 export type TimestampFn = () => TimestampValue

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,12 +198,32 @@ export interface BenchOptions {
    * timestamp provider call cost `C`. When this option is `true`, an
    * estimate `Ĉ` is computed once at construction time via
    * {@link calibrateTimerOverhead}, and `max(0, raw_sample - Ĉ)` is used
-   * instead. Only location statistics (mean, percentiles) are corrected;
-   * variance, standard deviation and relative margin of error are not, since
-   * subtracting a constant does not reduce dispersion.
+   * in place of each non-overridden sample before statistics are computed.
    *
-   * Samples returned by the task function via `overriddenDuration` are
-   * intentional user values and are never modified by the correction.
+   * **Statistics after correction.** All statistics (mean, percentiles,
+   * variance, sd, sem, moe, rme) are computed on the clamped corrected
+   * samples, not on the original distribution. When raw samples comfortably
+   * exceed `Ĉ` (`X >> Ĉ`), the clamp `max(0, …)` rarely triggers and the
+   * correction approximates a clean shift: location statistics improve and
+   * dispersion statistics are largely unaffected. When raw samples are
+   * comparable to the overhead (`X ≈ Ĉ`, typical for nano-scale
+   * operations), the clamp truncates the lower tail of the distribution,
+   * which introduces a small positive bias on the corrected mean and
+   * contracts variance/sd/sem/moe while potentially inflating rme. For
+   * sub-overhead measurements, prefer `overriddenDuration` instead.
+   *
+   * **Caveat — `concurrency: "task"`.** The overhead is calibrated once at
+   * construction time with sequential timer calls. When
+   * `concurrency: "task"` is set, the constructor throws because the
+   * sequentially-calibrated estimate would not reflect the per-iteration
+   * timer call cost under concurrent execution.
+   *
+   * **Caveat — `overriddenDuration`.** Samples returned by the task
+   * function via `overriddenDuration` are intentional user values and are
+   * never modified by the correction. They are also excluded from
+   * timer-saturation detection so that a deterministic synthetic
+   * `overriddenDuration` does not produce a spurious `'warning'` event via
+   * the low-distinct-count criterion.
    *
    * On runtimes with a coarse timer (resolution >= 1 ms), the calibration
    * returns `0` and this option becomes a no-op.
@@ -413,7 +433,6 @@ export type JSRuntime =
   | 'v8'
   | 'workerd'
 
-/**
 /**
  * A function that returns the current timestamp.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,10 +122,12 @@ export interface BenchLike extends EventTarget {
    */
   time: number
   /**
-   * The estimated cost of one timestamp provider call in milliseconds, or
-   * `undefined` when timer overhead subtraction is disabled.
+   * The estimated cost of one timestamp provider call in milliseconds.
+   *
+   * Calibrated once at construction; `undefined` (or omitted) when timer
+   * overhead subtraction is disabled or unsupported by the implementation.
    */
-  timerOverhead: number | undefined
+  readonly timerOverhead?: number
   /**
    * The timestamp provider used by the benchmark.
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,33 +202,50 @@ export interface BenchOptions {
    * {@link calibrateTimerOverhead}, and `max(0, raw_sample - Ĉ)` is used
    * in place of each non-overridden sample before statistics are computed.
    *
-   * **Statistics after correction.** All statistics (mean, percentiles,
-   * variance, sd, sem, moe, rme) are computed on the clamped corrected
-   * samples, not on the original distribution. When raw samples comfortably
-   * exceed `Ĉ` (`X >> Ĉ`), the clamp `max(0, …)` rarely triggers and the
-   * correction approximates a clean shift: location statistics improve and
-   * dispersion statistics are largely unaffected. When raw samples are
-   * comparable to the overhead (`X ≈ Ĉ`, typical for nano-scale
-   * operations), the clamp truncates the lower tail of the distribution,
-   * which introduces a small positive bias on the corrected mean and
-   * contracts variance/sd/sem/moe while potentially inflating rme. For
-   * sub-overhead measurements, prefer `overriddenDuration` instead.
+   * **Statistics after correction.** All fields of {@link Statistics} are
+   * derived from the clamped corrected samples, not from the raw
+   * distribution. With `M` denoting the raw-sample mean:
    *
-   * **Caveat — `concurrency: "task"`.** The overhead is calibrated once at
-   * construction time with sequential timer calls. When
-   * `concurrency: "task"` is set, the constructor throws because the
+   * - **Clean-shift regime (`X >> Ĉ`).** The clamp `max(0, …)` rarely
+   *   triggers, so the correction acts as a translation by `Ĉ`. Location
+   *   statistics (`mean`, `min`, `max`, all percentiles) decrease by `Ĉ`;
+   *   absolute-unit dispersion (`vr`, `sd`, `sem`, `moe`, `mad`, `aad`)
+   *   is essentially unchanged. Because `rme = moe / mean`, it inflates
+   *   by the deterministic factor `M / (M − Ĉ)` whenever `Ĉ > 0`.
+   * - **Sub-overhead regime (`X ≈ Ĉ`).** A non-trivial fraction of
+   *   samples clamp to `0`, biasing the corrected mean upward,
+   *   contracting `vr`/`sd`/`sem`/`moe`/`aad`, and compounding the
+   *   `M / (M − Ĉ)` factor in `rme`. Once the cumulative mass of raw
+   *   samples at or below `Ĉ` reaches a given quantile, that percentile
+   *   collapses to `0`; in particular `p50` collapses once at least half
+   *   of the raw samples satisfy `raw_sample ≤ Ĉ`, which then forces
+   *   `mad` and `aad` toward `0`. Prefer `overriddenDuration` for
+   *   sub-overhead measurements.
+   *
+   * **Three observable consequences of the clamp.**
+   *
+   * 1. `latency.min` may be exactly `0` even when no zero-duration sample
+   *    was actually observed.
+   * 2. The throughput estimator substitutes `1000 / latency.mean` (or `0`
+   *    when `mean === 0`) for every clamped sample.
+   * 3. {@link detectTimerSaturation} criterion `'zero-dominated'` cannot
+   *    distinguish clamped samples from genuine zero-duration timer
+   *    reads, so a `'warning'` event may be dispatched in the
+   *    sub-overhead regime even when the timer itself is not saturated.
+   *
+   * **Caveat — `concurrency: "task"`.** The overhead is calibrated once
+   * at construction time with sequential timer calls. Setting both
+   * options causes the constructor (and `run()`) to throw, since the
    * sequentially-calibrated estimate would not reflect the per-iteration
    * timer call cost under concurrent execution.
    *
    * **Caveat — `overriddenDuration`.** Samples returned by the task
-   * function via `overriddenDuration` are intentional user values and are
-   * never modified by the correction. They are also excluded from
-   * timer-saturation detection so that a deterministic synthetic
-   * `overriddenDuration` does not produce a spurious `'warning'` event via
-   * the low-distinct-count criterion.
+   * function via `overriddenDuration` are intentional user values and
+   * are never modified by the correction. They are also excluded from
+   * {@link Task.detectedResolution} and from timer-saturation detection.
    *
-   * On runtimes with a coarse timer (resolution >= 1 ms), the calibration
-   * returns `0` and this option becomes a no-op.
+   * On runtimes with a coarse timer (resolution >= 1 ms), the
+   * calibration returns `0` and this option becomes a no-op.
    * @default false
    */
   subtractTimerOverhead?: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -498,17 +498,20 @@ export const calibrateTimerOverhead = (
   const { estimator = 'median', pairs = 1024, warmupPairs = 64 } = options
   const { fn, toMs } = provider
 
-  // Degenerate input: no positive pairs to measure ⇒ no overhead estimate.
-  if (pairs <= 0) return 0
+  // Degenerate or non-finite input: `Number.isInteger` also rejects
+  // Infinity/NaN/non-integer counts that would otherwise hang the loop.
+  if (!Number.isInteger(pairs) || pairs <= 0) return 0
 
   // `fn` returns TimestampValue (`bigint | number`); both operands always
   // share a runtime type. Casting both to `bigint` lets the operator
   // typecheck without a type predicate; at runtime the `-` operator is
   // polymorphic for both numeric branches and `toMs` accepts either.
-  for (let i = 0; i < warmupPairs; i++) {
-    const a = fn() as bigint
-    const b = fn() as bigint
-    toMs(b - a)
+  if (Number.isInteger(warmupPairs) && warmupPairs > 0) {
+    for (let i = 0; i < warmupPairs; i++) {
+      const a = fn() as bigint
+      const b = fn() as bigint
+      toMs(b - a)
+    }
   }
 
   const deltas: number[] = []

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -261,6 +261,90 @@ export const isValidSamples = (
 }
 
 /**
+ * Detects timer saturation in a latency sample set.
+ *
+ * Saturation is reported when the timer resolution dominates the
+ * measurement, i.e. when at least one of the following holds:
+ * - more than half of the samples are zero
+ * - the number of distinct sample values is below `max(3, min(10, n / 1000))`
+ * - the median absolute deviation is zero with more than 100 samples
+ *
+ * Fewer than 10 samples are never flagged as saturated: with so few
+ * measurements the criteria cannot reliably distinguish a deterministic
+ * fast function (e.g. `iterations: 1`) from one truly limited by the timer
+ * grain.
+ *
+ * The distinct-value count is computed in O(n) by exploiting the
+ * sorted-ascending invariant of `samples` (`Task#processRunResult` calls
+ * `sortSamples` before this function).
+ * @param samples - the latency samples, sorted ascending
+ * @param mad - the median absolute deviation, as computed by computeStatistics
+ * @returns true when the timer resolution dominates the measurement
+ */
+export const detectTimerSaturation = (
+  samples: Samples,
+  mad: number
+): boolean => {
+  const n = samples.length
+  if (n < 10) return false
+
+  let zeroCount = 0
+  for (const s of samples) {
+    if (s === 0) zeroCount++
+  }
+  if (zeroCount * 2 > n) return true
+
+  let distinctCount = 1
+  for (let i = 1; i < n; i++) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (samples[i]! !== samples[i - 1]!) distinctCount++
+  }
+  const distinctThreshold = Math.max(3, Math.min(10, Math.floor(n / 1000)))
+  if (distinctCount < distinctThreshold) return true
+
+  if (n > 100 && mad === 0) return true
+
+  return false
+}
+
+/**
+ * Estimates the effective timer resolution from a latency sample set.
+ *
+ * The estimator returns the smallest strictly positive sample value that
+ * appears at least twice (the smallest reproducibly observed increment).
+ * Requiring two occurrences gives a 2/n breakdown point and avoids being
+ * pulled to an artificially low value by a single anomalous sample (cold
+ * cache, GC pause, hardware quirk).
+ *
+ * When no positive value appears more than once (e.g. a continuous
+ * sub-microsecond timer with all unique samples), falls back to the strict
+ * minimum of the positive values, which is the best available lower bound
+ * in that case.
+ * @param samples - the latency samples (sorted or unsorted)
+ * @returns the estimated resolution in milliseconds, or `undefined` when no
+ *   strictly positive sample is observed
+ */
+export const estimateResolution = (
+  samples: Samples
+): number | undefined => {
+  const counts = new Map<number, number>()
+  let fallbackMin = Number.POSITIVE_INFINITY
+  for (const s of samples) {
+    if (s > 0) {
+      counts.set(s, (counts.get(s) ?? 0) + 1)
+      if (s < fallbackMin) fallbackMin = s
+    }
+  }
+  if (fallbackMin === Number.POSITIVE_INFINITY) return undefined
+
+  let robustMin = Number.POSITIVE_INFINITY
+  for (const [v, c] of counts) {
+    if (c >= 2 && v < robustMin) robustMin = v
+  }
+  return robustMin === Number.POSITIVE_INFINITY ? fallbackMin : robustMin
+}
+
+/**
  * Sorts samples in place.
  * @param samples - samples to sort
  */
@@ -331,6 +415,110 @@ const quantileSorted = (
  * @returns a number indicating the sort order
  */
 export const sortFn = (a: number, b: number) => a - b
+
+/**
+ * Options for {@link calibrateTimerOverhead}.
+ */
+export interface CalibrateTimerOverheadOptions {
+  /**
+   * Estimator used to reduce the distribution of strictly-positive
+   * back-to-back call deltas to a single overhead value.
+   * @default 'median'
+   */
+  estimator?: TimerOverheadEstimator
+  /**
+   * Number of back-to-back call pairs to measure during the collection phase.
+   * @default 1024
+   */
+  samples?: number
+  /**
+   * Number of discarded warm-up pairs executed before the collection phase,
+   * allowing the JIT to reach a steady compilation tier for both
+   * `provider.fn` and `provider.toMs`.
+   * @default 64
+   */
+  warmupSamples?: number
+}
+
+/**
+ * Estimator strategy for {@link calibrateTimerOverhead}.
+ *
+ * - `'median'` — median of strictly-positive deltas (default). Robust to
+ *   occasional OS-scheduling jitter and GC spikes at the cost of a slight
+ *   upward bias on noisy hosts.
+ * - `'min'` — minimum of strictly-positive deltas. Captures the lowest
+ *   observed call cost.
+ * - `'p05'` — 5th percentile of strictly-positive deltas. A compromise
+ *   between robustness and tightness.
+ */
+export type TimerOverheadEstimator = 'median' | 'min' | 'p05'
+
+/**
+ * Estimates the cost of a single `provider.fn()` call by repeatedly measuring
+ * back-to-back pairs and reducing the strictly-positive deltas to a single
+ * value via the chosen estimator.
+ *
+ * **Coarse-timer detection.** When the timer resolution `R` exceeds the call
+ * cost `C` (`C < R / 2`), the probability that any pair crosses a tick
+ * boundary is `C / R < 1 / 2`, so most pairs return a delta of zero. The
+ * positive deltas that do occur each equal exactly one tick `R`, not the
+ * call cost. To prevent catastrophic over-correction, the function returns
+ * `0` whenever fewer than half of the pairs produce a positive delta.
+ *
+ * **Bigint precision.** The subtraction is performed in the provider's
+ * native type before conversion to milliseconds (`toMs(b - a)`). For
+ * `hrtimeNow`, this preserves precision when absolute timestamps exceed
+ * `Number.MAX_SAFE_INTEGER` ns (≈ 104 days uptime).
+ *
+ * **JIT warmup.** A discarded warmup phase ensures `fn` and `toMs` are
+ * JIT-compiled to their steady-state tier before measurements begin.
+ * @param provider - the timestamp provider to calibrate
+ * @param options - calibration options
+ * @returns the estimated overhead in milliseconds, never negative; `0` when
+ *   the timer resolution dominates or no positive delta is observed
+ */
+export const calibrateTimerOverhead = (
+  provider: TimestampProvider,
+  options: CalibrateTimerOverheadOptions = {}
+): number => {
+  const { estimator = 'median', samples = 1024, warmupSamples = 64 } = options
+  const { fn, toMs } = provider
+
+  for (let i = 0; i < warmupSamples; i++) {
+    const a = fn() as unknown as number
+    const b = fn() as unknown as number
+    toMs(b - a)
+  }
+
+  const deltas: number[] = []
+  for (let i = 0; i < samples; i++) {
+    const a = fn() as unknown as number
+    const b = fn() as unknown as number
+    const delta = toMs(b - a)
+    if (delta > 0) deltas.push(delta)
+  }
+
+  if (deltas.length * 2 < samples) return 0
+  if (deltas.length === 0) return 0
+
+  deltas.sort(sortFn)
+
+  if (estimator === 'min') {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return deltas[0]!
+  }
+  if (estimator === 'p05') {
+    const idx = Math.max(0, Math.ceil(deltas.length * 0.05) - 1)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return deltas[idx]!
+  }
+  const mid = deltas.length >> 1
+  return (deltas.length & 1) === 1
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    ? deltas[mid]!
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    : (deltas[mid - 1]! + deltas[mid]!) / 2
+}
 
 /**
  * Computes the average absolute deviation from the mean.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,7 +275,7 @@ export const isValidSamples = (
  * the threshold is reached.
  * @param samples - the latency samples, sorted ascending
  * @param mad - the median absolute deviation (e.g. from
- *   {@link medianAbsoluteDeviation} or {@link computeStatistics})
+ *   {@link medianAbsoluteDeviation} or `computeStatistics`)
  * @returns the saturation reason, or `undefined` when no criterion fires
  */
 export const classifyTimerSaturation = (
@@ -617,8 +617,8 @@ export function absoluteDeviationMedian (
  * Computes the median absolute deviation (MAD) of a sorted sample set.
  *
  * Convenience wrapper that derives the median from the sorted input and
- * forwards to {@link absoluteDeviationMedian}. Use when only `mad` is
- * required and the cost of a full {@link computeStatistics} pass is
+ * forwards to `absoluteDeviationMedian`. Use when only `mad` is
+ * required and the cost of a full `computeStatistics` pass is
  * unjustified (e.g. inside {@link classifyTimerSaturation}).
  * @param samples - the sorted sample, length ≥ 1
  * @returns the median absolute deviation

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import type {
   Samples,
   SortedSamples,
   Statistics,
+  TimerSaturationReason,
   TimestampProvider,
   TimestampValue,
 } from './types'
@@ -259,20 +260,6 @@ export const isValidSamples = (
 ): value is Samples => {
   return Array.isArray(value) && value.length !== 0
 }
-
-/**
- * Reason a sample set is classified as timer-saturated.
- *
- * - `'zero-dominated'` — more than half of the samples are exactly zero.
- * - `'low-distinct'` — distinct sample count is below
- *   `max(3, min(10, ⌊n / 1000⌋))`.
- * - `'zero-mad'` — median absolute deviation is zero with more than 100
- *   samples.
- */
-export type TimerSaturationReason =
-  | 'low-distinct'
-  | 'zero-dominated'
-  | 'zero-mad'
 
 /**
  * Classifies timer saturation in a latency sample set.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -444,14 +444,14 @@ export interface CalibrateTimerOverheadOptions {
    * Number of back-to-back call pairs to measure during the collection phase.
    * @default 1024
    */
-  samples?: number
+  pairs?: number
   /**
    * Number of discarded warm-up pairs executed before the collection phase,
    * allowing the JIT to reach a steady compilation tier for both
    * `provider.fn` and `provider.toMs`.
    * @default 64
    */
-  warmupSamples?: number
+  warmupPairs?: number
 }
 
 /**
@@ -495,28 +495,28 @@ export const calibrateTimerOverhead = (
   provider: TimestampProvider,
   options: CalibrateTimerOverheadOptions = {}
 ): number => {
-  const { estimator = 'median', samples = 1024, warmupSamples = 64 } = options
+  const { estimator = 'median', pairs = 1024, warmupPairs = 64 } = options
   const { fn, toMs } = provider
 
   // `fn` returns TimestampValue (`bigint | number`); both operands always
   // share a runtime type. Casting both to `bigint` lets the operator
   // typecheck without a type predicate; at runtime the `-` operator is
   // polymorphic for both numeric branches and `toMs` accepts either.
-  for (let i = 0; i < warmupSamples; i++) {
+  for (let i = 0; i < warmupPairs; i++) {
     const a = fn() as bigint
     const b = fn() as bigint
     toMs(b - a)
   }
 
   const deltas: number[] = []
-  for (let i = 0; i < samples; i++) {
+  for (let i = 0; i < pairs; i++) {
     const a = fn() as bigint
     const b = fn() as bigint
     const delta = toMs(b - a)
     if (delta > 0) deltas.push(delta)
   }
 
-  if (deltas.length * 2 < samples) return 0
+  if (deltas.length * 2 < pairs) return 0
   if (deltas.length === 0) return 0
 
   deltas.sort(sortFn)
@@ -526,6 +526,8 @@ export const calibrateTimerOverhead = (
     return deltas[0]!
   }
   if (estimator === 'p05') {
+    // Nearest-rank: returns an actually observed delta, deliberately not the
+    // interpolated `quantileSorted` (whose `q` union excludes 0.05 anyway).
     const idx = Math.max(0, Math.ceil(deltas.length * 0.05) - 1)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return deltas[idx]!

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -498,8 +498,8 @@ export const calibrateTimerOverhead = (
   const { estimator = 'median', pairs = 1024, warmupPairs = 64 } = options
   const { fn, toMs } = provider
 
-  // Degenerate input: no pairs to measure ⇒ no overhead estimate.
-  if (pairs === 0) return 0
+  // Degenerate input: no positive pairs to measure ⇒ no overhead estimate.
+  if (pairs <= 0) return 0
 
   // `fn` returns TimestampValue (`bigint | number`); both operands always
   // share a runtime type. Casting both to `bigint` lets the operator

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -498,6 +498,9 @@ export const calibrateTimerOverhead = (
   const { estimator = 'median', pairs = 1024, warmupPairs = 64 } = options
   const { fn, toMs } = provider
 
+  // Degenerate input: no pairs to measure ⇒ no overhead estimate.
+  if (pairs === 0) return 0
+
   // `fn` returns TimestampValue (`bigint | number`); both operands always
   // share a runtime type. Casting both to `bigint` lets the operator
   // typecheck without a type predicate; at runtime the `-` operator is
@@ -517,7 +520,6 @@ export const calibrateTimerOverhead = (
   }
 
   if (deltas.length * 2 < pairs) return 0
-  if (deltas.length === 0) return 0
 
   deltas.sort(sortFn)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -261,51 +261,79 @@ export const isValidSamples = (
 }
 
 /**
- * Detects timer saturation in a latency sample set.
+ * Reason a sample set is classified as timer-saturated.
  *
- * Saturation is reported when the timer resolution dominates the
- * measurement, i.e. when at least one of the following holds:
- * - more than half of the samples are zero
- * - the number of distinct sample values is below `max(3, min(10, n / 1000))`
- * - the median absolute deviation is zero with more than 100 samples
+ * - `'zero-dominated'` — more than half of the samples are exactly zero.
+ * - `'low-distinct'` — distinct sample count is below
+ *   `max(3, min(10, ⌊n / 1000⌋))`.
+ * - `'zero-mad'` — median absolute deviation is zero with more than 100
+ *   samples.
+ */
+export type TimerSaturationReason =
+  | 'low-distinct'
+  | 'zero-dominated'
+  | 'zero-mad'
+
+/**
+ * Classifies timer saturation in a latency sample set.
  *
- * Fewer than 10 samples are never flagged as saturated: with so few
- * measurements the criteria cannot reliably distinguish a deterministic
- * fast function (e.g. `iterations: 1`) from one truly limited by the timer
- * grain.
+ * Criteria are evaluated in the fixed order `'zero-dominated'` →
+ * `'low-distinct'` → `'zero-mad'`; the first match wins. Fewer than 10
+ * samples are never classified — with so few measurements the criteria
+ * cannot reliably distinguish a deterministic fast function from one truly
+ * limited by the timer grain.
  *
  * The distinct-value count is computed in O(n) by exploiting the
- * sorted-ascending invariant of `samples` (`Task#processRunResult` calls
- * `sortSamples` before this function).
+ * sorted-ascending invariant of `samples` and short-circuits as soon as
+ * the threshold is reached.
  * @param samples - the latency samples, sorted ascending
- * @param mad - the median absolute deviation, as computed by computeStatistics
- * @returns true when the timer resolution dominates the measurement
+ * @param mad - the median absolute deviation (e.g. from
+ *   {@link medianAbsoluteDeviation} or {@link computeStatistics})
+ * @returns the saturation reason, or `undefined` when no criterion fires
  */
-export const detectTimerSaturation = (
-  samples: Samples,
+export const classifyTimerSaturation = (
+  samples: SortedSamples,
   mad: number
-): boolean => {
+): TimerSaturationReason | undefined => {
   const n = samples.length
-  if (n < 10) return false
+  if (n < 10) return undefined
 
   let zeroCount = 0
   for (const s of samples) {
     if (s === 0) zeroCount++
   }
-  if (zeroCount * 2 > n) return true
+  if (zeroCount * 2 > n) return 'zero-dominated'
 
+  const distinctThreshold = Math.max(3, Math.min(10, Math.floor(n / 1000)))
   let distinctCount = 1
   for (let i = 1; i < n; i++) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    if (samples[i]! !== samples[i - 1]!) distinctCount++
+    if (samples[i]! !== samples[i - 1]!) {
+      distinctCount++
+      if (distinctCount >= distinctThreshold) break
+    }
   }
-  const distinctThreshold = Math.max(3, Math.min(10, Math.floor(n / 1000)))
-  if (distinctCount < distinctThreshold) return true
+  if (distinctCount < distinctThreshold) return 'low-distinct'
 
-  if (n > 100 && mad === 0) return true
+  if (n > 100 && mad === 0) return 'zero-mad'
 
-  return false
+  return undefined
 }
+
+/**
+ * Detects timer saturation in a latency sample set.
+ *
+ * Boolean wrapper around {@link classifyTimerSaturation}; prefer the
+ * classifier when the specific reason is needed (e.g. to surface it on a
+ * `'warning'` event).
+ * @param samples - the latency samples, sorted ascending
+ * @param mad - the median absolute deviation
+ * @returns `true` when a saturation criterion fires, `false` otherwise
+ */
+export const detectTimerSaturation = (
+  samples: SortedSamples,
+  mad: number
+): boolean => classifyTimerSaturation(samples, mad) !== undefined
 
 /**
  * Estimates the effective timer resolution from a latency sample set.
@@ -425,7 +453,7 @@ export interface CalibrateTimerOverheadOptions {
    * back-to-back call deltas to a single overhead value.
    * @default 'median'
    */
-  estimator?: TimerOverheadEstimator
+  estimator?: TimerOverheadEstimatorKind
   /**
    * Number of back-to-back call pairs to measure during the collection phase.
    * @default 1024
@@ -451,7 +479,7 @@ export interface CalibrateTimerOverheadOptions {
  * - `'p05'` — 5th percentile of strictly-positive deltas. A compromise
  *   between robustness and tightness.
  */
-export type TimerOverheadEstimator = 'median' | 'min' | 'p05'
+export type TimerOverheadEstimatorKind = 'median' | 'min' | 'p05'
 
 /**
  * Estimates the cost of a single `provider.fn()` call by repeatedly measuring
@@ -484,16 +512,20 @@ export const calibrateTimerOverhead = (
   const { estimator = 'median', samples = 1024, warmupSamples = 64 } = options
   const { fn, toMs } = provider
 
+  // `fn` returns TimestampValue (`bigint | number`); both operands always
+  // share a runtime type. Casting both to `bigint` lets the operator
+  // typecheck without a type predicate; at runtime the `-` operator is
+  // polymorphic for both numeric branches and `toMs` accepts either.
   for (let i = 0; i < warmupSamples; i++) {
-    const a = fn() as unknown as number
-    const b = fn() as unknown as number
+    const a = fn() as bigint
+    const b = fn() as bigint
     toMs(b - a)
   }
 
   const deltas: number[] = []
   for (let i = 0; i < samples; i++) {
-    const a = fn() as unknown as number
-    const b = fn() as unknown as number
+    const a = fn() as bigint
+    const b = fn() as bigint
     const delta = toMs(b - a)
     if (delta > 0) deltas.push(delta)
   }
@@ -593,6 +625,19 @@ export function absoluteDeviationMedian (
   }
   return 0 // should never reach here
 }
+
+/**
+ * Computes the median absolute deviation (MAD) of a sorted sample set.
+ *
+ * Convenience wrapper that derives the median from the sorted input and
+ * forwards to {@link absoluteDeviationMedian}. Use when only `mad` is
+ * required and the cost of a full {@link computeStatistics} pass is
+ * unjustified (e.g. inside {@link classifyTimerSaturation}).
+ * @param samples - the sorted sample, length ≥ 1
+ * @returns the median absolute deviation
+ */
+export const medianAbsoluteDeviation = (samples: SortedSamples): number =>
+  absoluteDeviationMedian(samples, quantileSorted(samples, 0.5))
 
 /**
  * Computes the statistics of a sample.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -335,28 +335,27 @@ export const detectTimerSaturation = (
  * sub-microsecond timer with all unique samples), falls back to the strict
  * minimum of the positive values, which is the best available lower bound
  * in that case.
- * @param samples - the latency samples (sorted or unsorted)
+ *
+ * Exploits the sorted-ascending invariant: equal values are contiguous, so
+ * the first strictly-positive value with an equal successor is the smallest
+ * reproduced value, and the first strictly-positive value is the fallback
+ * minimum. Runs in O(1) extra space with an early exit.
+ * @param samples - the latency samples, sorted ascending
  * @returns the estimated resolution in milliseconds, or `undefined` when no
  *   strictly positive sample is observed
  */
 export const estimateResolution = (
-  samples: Samples
+  samples: SortedSamples
 ): number | undefined => {
-  const counts = new Map<number, number>()
-  let fallbackMin = Number.POSITIVE_INFINITY
-  for (const s of samples) {
-    if (s > 0) {
-      counts.set(s, (counts.get(s) ?? 0) + 1)
-      if (s < fallbackMin) fallbackMin = s
-    }
+  let fallbackMin: number | undefined
+  for (let i = 0; i < samples.length; i++) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const v = samples[i]!
+    if (v <= 0) continue
+    fallbackMin ??= v
+    if (samples[i + 1] === v) return v
   }
-  if (fallbackMin === Number.POSITIVE_INFINITY) return undefined
-
-  let robustMin = Number.POSITIVE_INFINITY
-  for (const [v, c] of counts) {
-    if (c >= 2 && v < robustMin) robustMin = v
-  }
-  return robustMin === Number.POSITIVE_INFINITY ? fallbackMin : robustMin
+  return fallbackMin
 }
 
 /**

--- a/test/calibrate-timer-overhead.test.ts
+++ b/test/calibrate-timer-overhead.test.ts
@@ -7,8 +7,29 @@ import {
   calibrateTimerOverhead,
   hrtimeNowTimestampProvider,
   mToMs,
+  nToMs,
   performanceNowTimestampProvider,
 } from '../src/utils'
+
+/**
+ * Deterministic provider: pair `i` returns `(0, i + 1)`, so the i-th
+ * collected delta equals `(i + 1)` ns. With `samples = N` the sorted
+ * deltas (in ms) are `[1, 2, …, N] × 1e-6`.
+ * @returns a fresh provider with its own counter
+ */
+const makeAscendingPairProvider = (): TimestampProvider => {
+  let callCount = 0
+  return {
+    fn: () => {
+      const idx = callCount++
+      const pairIdx = idx >> 1
+      return (idx & 1) === 1 ? pairIdx + 1 : 0
+    },
+    fromMs: ms => ms * 1_000_000,
+    name: 'asc-pairs',
+    toMs: nToMs,
+  }
+}
 
 test('calibrateTimerOverhead returns a finite non-negative number with performanceNow', () => {
   const overhead = calibrateTimerOverhead(performanceNowTimestampProvider)
@@ -45,16 +66,49 @@ test('calibrateTimerOverhead returns 0 for a coarse 1 ms timer provider', () => 
   expect(calibrateTimerOverhead(coarseProvider, { samples: 1024 })).toBe(0)
 })
 
-test('calibrateTimerOverhead estimator min is less than or equal to median', () => {
-  const med = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
-    estimator: 'median',
-    samples: 512,
-  })
-  const min = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
+test('calibrateTimerOverhead estimators are ordered min ≤ p05 ≤ median', () => {
+  const min = calibrateTimerOverhead(makeAscendingPairProvider(), {
     estimator: 'min',
-    samples: 512,
+    samples: 100,
+    warmupSamples: 0,
   })
-  expect(min).toBeLessThanOrEqual(med * 2)
+  const p05 = calibrateTimerOverhead(makeAscendingPairProvider(), {
+    estimator: 'p05',
+    samples: 100,
+    warmupSamples: 0,
+  })
+  const median = calibrateTimerOverhead(makeAscendingPairProvider(), {
+    estimator: 'median',
+    samples: 100,
+    warmupSamples: 0,
+  })
+  expect(min).toBe(1e-6)
+  expect(p05).toBe(5e-6)
+  expect(median).toBe(50.5e-6)
+})
+
+test("calibrateTimerOverhead 'p05' selects the index ⌈n·0.05⌉ − 1 delta", () => {
+  expect(
+    calibrateTimerOverhead(makeAscendingPairProvider(), {
+      estimator: 'p05',
+      samples: 20,
+      warmupSamples: 0,
+    })
+  ).toBe(1e-6)
+  expect(
+    calibrateTimerOverhead(makeAscendingPairProvider(), {
+      estimator: 'p05',
+      samples: 21,
+      warmupSamples: 0,
+    })
+  ).toBe(2e-6)
+  expect(
+    calibrateTimerOverhead(makeAscendingPairProvider(), {
+      estimator: 'p05',
+      samples: 200,
+      warmupSamples: 0,
+    })
+  ).toBe(10e-6)
 })
 
 test('calibrateTimerOverhead with hrtimeNow returns a plausible overhead under 10 microseconds', () => {
@@ -105,4 +159,21 @@ test('subtractTimerOverhead: true does not produce negative latency samples', ()
 
   expect(fooTask.result.latency.min).toBeGreaterThanOrEqual(0)
   expect(fooTask.result.latency.mean).toBeGreaterThanOrEqual(0)
+})
+
+test('subtractTimerOverhead with concurrency: "task" throws at construction', () => {
+  expect(
+    () => new Bench({ concurrency: 'task', subtractTimerOverhead: true })
+  ).toThrow(/cannot be used with `concurrency: "task"`/)
+})
+
+test('subtractTimerOverhead enforces concurrency invariant at run()', async () => {
+  const bench = new Bench({ subtractTimerOverhead: true })
+  bench.add('noop', () => {
+    // noop
+  })
+  ;(bench as { concurrency: 'bench' | 'task' | null }).concurrency = 'task'
+  await expect(bench.run()).rejects.toThrow(
+    /cannot be used with `concurrency: "task"`/
+  )
 })

--- a/test/calibrate-timer-overhead.test.ts
+++ b/test/calibrate-timer-overhead.test.ts
@@ -52,7 +52,7 @@ test('calibrateTimerOverhead returns 0 for a fixed-value provider', () => {
     name: 'fixed',
     toMs: mToMs,
   }
-  expect(calibrateTimerOverhead(fixedProvider, { samples: 256 })).toBe(0)
+  expect(calibrateTimerOverhead(fixedProvider, { pairs: 256 })).toBe(0)
 })
 
 test('calibrateTimerOverhead returns 0 for a coarse 1 ms timer provider', () => {
@@ -63,24 +63,24 @@ test('calibrateTimerOverhead returns 0 for a coarse 1 ms timer provider', () => 
     name: 'coarse',
     toMs: mToMs,
   }
-  expect(calibrateTimerOverhead(coarseProvider, { samples: 1024 })).toBe(0)
+  expect(calibrateTimerOverhead(coarseProvider, { pairs: 1024 })).toBe(0)
 })
 
 test('calibrateTimerOverhead estimators are ordered min ≤ p05 ≤ median', () => {
   const min = calibrateTimerOverhead(makeAscendingPairProvider(), {
     estimator: 'min',
-    samples: 100,
-    warmupSamples: 0,
+    pairs: 100,
+    warmupPairs: 0,
   })
   const p05 = calibrateTimerOverhead(makeAscendingPairProvider(), {
     estimator: 'p05',
-    samples: 100,
-    warmupSamples: 0,
+    pairs: 100,
+    warmupPairs: 0,
   })
   const median = calibrateTimerOverhead(makeAscendingPairProvider(), {
     estimator: 'median',
-    samples: 100,
-    warmupSamples: 0,
+    pairs: 100,
+    warmupPairs: 0,
   })
   expect(min).toBe(1e-6)
   expect(p05).toBe(5e-6)
@@ -91,22 +91,22 @@ test("calibrateTimerOverhead 'p05' selects the index ⌈n·0.05⌉ − 1 delta",
   expect(
     calibrateTimerOverhead(makeAscendingPairProvider(), {
       estimator: 'p05',
-      samples: 20,
-      warmupSamples: 0,
+      pairs: 20,
+      warmupPairs: 0,
     })
   ).toBe(1e-6)
   expect(
     calibrateTimerOverhead(makeAscendingPairProvider(), {
       estimator: 'p05',
-      samples: 21,
-      warmupSamples: 0,
+      pairs: 21,
+      warmupPairs: 0,
     })
   ).toBe(2e-6)
   expect(
     calibrateTimerOverhead(makeAscendingPairProvider(), {
       estimator: 'p05',
-      samples: 200,
-      warmupSamples: 0,
+      pairs: 200,
+      warmupPairs: 0,
     })
   ).toBe(10e-6)
 })
@@ -114,7 +114,7 @@ test("calibrateTimerOverhead 'p05' selects the index ⌈n·0.05⌉ − 1 delta",
 test('calibrateTimerOverhead with hrtimeNow returns a plausible overhead under 10 microseconds', () => {
   const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
     estimator: 'median',
-    samples: 1024,
+    pairs: 1024,
   })
   if (overhead > 0) {
     expect(overhead).toBeLessThan(0.01)

--- a/test/calibrate-timer-overhead.test.ts
+++ b/test/calibrate-timer-overhead.test.ts
@@ -66,6 +66,20 @@ test('calibrateTimerOverhead returns 0 for a coarse 1 ms timer provider', () => 
   expect(calibrateTimerOverhead(coarseProvider, { pairs: 1024 })).toBe(0)
 })
 
+test('calibrateTimerOverhead returns 0 for non-positive pairs', () => {
+  for (const pairs of [0, -1, -1024]) {
+    for (const estimator of ['median', 'min', 'p05'] as const) {
+      expect(
+        calibrateTimerOverhead(makeAscendingPairProvider(), {
+          estimator,
+          pairs,
+          warmupPairs: 0,
+        })
+      ).toBe(0)
+    }
+  }
+})
+
 test('calibrateTimerOverhead estimators are ordered min ≤ p05 ≤ median', () => {
   const min = calibrateTimerOverhead(makeAscendingPairProvider(), {
     estimator: 'min',

--- a/test/calibrate-timer-overhead.test.ts
+++ b/test/calibrate-timer-overhead.test.ts
@@ -80,6 +80,24 @@ test('calibrateTimerOverhead returns 0 for non-positive pairs', () => {
   }
 })
 
+test('calibrateTimerOverhead returns 0 for non-finite or non-integer pairs', () => {
+  for (const pairs of [Infinity, -Infinity, NaN, 1.5]) {
+    expect(calibrateTimerOverhead(makeAscendingPairProvider(), { pairs })).toBe(
+      0
+    )
+  }
+})
+
+test('calibrateTimerOverhead does not hang on non-finite warmupPairs', () => {
+  for (const warmupPairs of [Infinity, NaN, -1, 2.5]) {
+    const overhead = calibrateTimerOverhead(makeAscendingPairProvider(), {
+      pairs: 100,
+      warmupPairs,
+    })
+    expect(Number.isFinite(overhead)).toBe(true)
+  }
+})
+
 test('calibrateTimerOverhead estimators are ordered min ≤ p05 ≤ median', () => {
   const min = calibrateTimerOverhead(makeAscendingPairProvider(), {
     estimator: 'min',

--- a/test/calibrate-timer-overhead.test.ts
+++ b/test/calibrate-timer-overhead.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from 'vitest'
+
+import type { TimestampProvider } from '../src/types'
+
+import { Bench } from '../src'
+import {
+  calibrateTimerOverhead,
+  hrtimeNowTimestampProvider,
+  mToMs,
+  performanceNowTimestampProvider,
+} from '../src/utils'
+
+test('calibrateTimerOverhead returns a finite non-negative number with performanceNow', () => {
+  const overhead = calibrateTimerOverhead(performanceNowTimestampProvider)
+  expect(overhead).toBeTypeOf('number')
+  expect(overhead).toBeGreaterThanOrEqual(0)
+  expect(Number.isFinite(overhead)).toBe(true)
+})
+
+test('calibrateTimerOverhead returns a finite non-negative number with hrtimeNow', () => {
+  const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider)
+  expect(overhead).toBeTypeOf('number')
+  expect(overhead).toBeGreaterThanOrEqual(0)
+  expect(Number.isFinite(overhead)).toBe(true)
+})
+
+test('calibrateTimerOverhead returns 0 for a fixed-value provider', () => {
+  const fixedProvider: TimestampProvider = {
+    fn: () => 42,
+    fromMs: mToMs,
+    name: 'fixed',
+    toMs: mToMs,
+  }
+  expect(calibrateTimerOverhead(fixedProvider, { samples: 256 })).toBe(0)
+})
+
+test('calibrateTimerOverhead returns 0 for a coarse 1 ms timer provider', () => {
+  let counter = 0
+  const coarseProvider: TimestampProvider = {
+    fn: () => Math.floor(counter++ / 64),
+    fromMs: mToMs,
+    name: 'coarse',
+    toMs: mToMs,
+  }
+  expect(calibrateTimerOverhead(coarseProvider, { samples: 1024 })).toBe(0)
+})
+
+test('calibrateTimerOverhead estimator min is less than or equal to median', () => {
+  const med = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
+    estimator: 'median',
+    samples: 512,
+  })
+  const min = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
+    estimator: 'min',
+    samples: 512,
+  })
+  expect(min).toBeLessThanOrEqual(med * 2)
+})
+
+test('calibrateTimerOverhead with hrtimeNow returns a plausible overhead under 10 microseconds', () => {
+  const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
+    estimator: 'median',
+    samples: 1024,
+  })
+  if (overhead > 0) {
+    expect(overhead).toBeLessThan(0.01)
+  } else {
+    expect(overhead).toBe(0)
+  }
+})
+
+test('subtractTimerOverhead defaults to false and leaves timerOverhead undefined', () => {
+  const bench = new Bench()
+  expect(bench.subtractTimerOverhead).toBe(false)
+  expect(bench.timerOverhead).toBeUndefined()
+})
+
+test('subtractTimerOverhead: true populates a finite non-negative timerOverhead', () => {
+  const bench = new Bench({ subtractTimerOverhead: true })
+  expect(bench.subtractTimerOverhead).toBe(true)
+  expect(bench.timerOverhead).toBeTypeOf('number')
+  expect(Number.isFinite(bench.timerOverhead)).toBe(true)
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  expect(bench.timerOverhead!).toBeGreaterThanOrEqual(0)
+})
+
+test('subtractTimerOverhead: true does not produce negative latency samples', () => {
+  const bench = new Bench({
+    iterations: 64,
+    subtractTimerOverhead: true,
+    time: 100,
+    warmup: false,
+  })
+  bench.add('noop', () => {
+    // noop
+  })
+  bench.runSync()
+
+  const fooTask = bench.getTask('noop')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+
+  expect(fooTask.result.state).toBe('completed')
+  if (fooTask.result.state !== 'completed') return
+
+  expect(fooTask.result.latency.min).toBeGreaterThanOrEqual(0)
+  expect(fooTask.result.latency.mean).toBeGreaterThanOrEqual(0)
+})

--- a/test/detected-resolution.test.ts
+++ b/test/detected-resolution.test.ts
@@ -52,11 +52,10 @@ test('Task.detectedResolution is populated after a successful run', () => {
   if (fooTask.result.state !== 'completed') return
 
   const resolution = fooTask.detectedResolution
-  if (resolution !== undefined) {
-    expect(resolution).toBeTypeOf('number')
-    expect(resolution).toBeGreaterThan(0)
-    expect(Number.isFinite(resolution)).toBe(true)
-  }
+  expect(resolution).toBeDefined()
+  expect(resolution).toBeTypeOf('number')
+  expect(resolution).toBeGreaterThan(0)
+  expect(Number.isFinite(resolution)).toBe(true)
 })
 
 test('Task.detectedResolution is reset to undefined by reset()', () => {

--- a/test/detected-resolution.test.ts
+++ b/test/detected-resolution.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'vitest'
+
+import type { Samples } from '../src/types'
+
+import { Bench } from '../src'
+import { estimateResolution } from '../src/utils'
+
+const asSamples = (arr: number[]): Samples => arr as unknown as Samples
+
+test('estimateResolution returns the smallest reproduced positive value', () => {
+  expect(estimateResolution(asSamples([0, 0, 0, 0.001, 1, 1, 1]))).toBe(1)
+  expect(estimateResolution(asSamples([0.5, 1, 1, 2, 2]))).toBe(1)
+  expect(estimateResolution(asSamples([0.1, 0.1, 0.5, 0.5]))).toBe(0.1)
+})
+
+test('estimateResolution falls back to strict min when no value repeats', () => {
+  expect(estimateResolution(asSamples([0, 0, 0.5, 1, 2]))).toBe(0.5)
+  expect(estimateResolution(asSamples([1, 2, 3]))).toBe(1)
+})
+
+test('estimateResolution returns the value itself when all positives are equal', () => {
+  expect(estimateResolution(asSamples([1, 1, 1, 1]))).toBe(1)
+})
+
+test('estimateResolution returns undefined when all samples are zero or negative', () => {
+  expect(estimateResolution(asSamples([0, 0, 0]))).toBeUndefined()
+  expect(estimateResolution(asSamples([0]))).toBeUndefined()
+  expect(estimateResolution(asSamples([0, -1, -0.5]))).toBeUndefined()
+})
+
+test('Task.detectedResolution is undefined before run', () => {
+  const bench = new Bench()
+  bench.add('foo', () => {
+    // noop
+  })
+  const fooTask = bench.getTask('foo')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+  expect(fooTask.detectedResolution).toBeUndefined()
+})
+
+test('Task.detectedResolution is populated after a successful run', () => {
+  const bench = new Bench({ iterations: 64, time: 100, warmup: false })
+  bench.add('foo', () => {
+    // noop
+  })
+  bench.runSync()
+  const fooTask = bench.getTask('foo')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+  expect(fooTask.result.state).toBe('completed')
+  if (fooTask.result.state !== 'completed') return
+
+  const resolution = fooTask.detectedResolution
+  if (resolution !== undefined) {
+    expect(resolution).toBeTypeOf('number')
+    expect(resolution).toBeGreaterThan(0)
+    expect(Number.isFinite(resolution)).toBe(true)
+  }
+})
+
+test('Task.detectedResolution is reset to undefined by reset()', () => {
+  const bench = new Bench({ iterations: 64, time: 100, warmup: false })
+  bench.add('foo', () => {
+    // noop
+  })
+  bench.runSync()
+  const fooTask = bench.getTask('foo')
+  expect(fooTask).toBeDefined()
+  if (!fooTask) return
+  fooTask.reset()
+  expect(fooTask.detectedResolution).toBeUndefined()
+})

--- a/test/detected-resolution.test.ts
+++ b/test/detected-resolution.test.ts
@@ -1,31 +1,32 @@
 import { expect, test } from 'vitest'
 
-import type { Samples } from '../src/types'
+import type { SortedSamples } from '../src/types'
 
 import { Bench } from '../src'
 import { estimateResolution } from '../src/utils'
 
-const asSamples = (arr: number[]): Samples => arr as unknown as Samples
+const asSorted = (arr: number[]): SortedSamples =>
+  arr as unknown as SortedSamples
 
 test('estimateResolution returns the smallest reproduced positive value', () => {
-  expect(estimateResolution(asSamples([0, 0, 0, 0.001, 1, 1, 1]))).toBe(1)
-  expect(estimateResolution(asSamples([0.5, 1, 1, 2, 2]))).toBe(1)
-  expect(estimateResolution(asSamples([0.1, 0.1, 0.5, 0.5]))).toBe(0.1)
+  expect(estimateResolution(asSorted([0, 0, 0, 0.001, 1, 1, 1]))).toBe(1)
+  expect(estimateResolution(asSorted([0.5, 1, 1, 2, 2]))).toBe(1)
+  expect(estimateResolution(asSorted([0.1, 0.1, 0.5, 0.5]))).toBe(0.1)
 })
 
 test('estimateResolution falls back to strict min when no value repeats', () => {
-  expect(estimateResolution(asSamples([0, 0, 0.5, 1, 2]))).toBe(0.5)
-  expect(estimateResolution(asSamples([1, 2, 3]))).toBe(1)
+  expect(estimateResolution(asSorted([0, 0, 0.5, 1, 2]))).toBe(0.5)
+  expect(estimateResolution(asSorted([1, 2, 3]))).toBe(1)
 })
 
 test('estimateResolution returns the value itself when all positives are equal', () => {
-  expect(estimateResolution(asSamples([1, 1, 1, 1]))).toBe(1)
+  expect(estimateResolution(asSorted([1, 1, 1, 1]))).toBe(1)
 })
 
 test('estimateResolution returns undefined when all samples are zero or negative', () => {
-  expect(estimateResolution(asSamples([0, 0, 0]))).toBeUndefined()
-  expect(estimateResolution(asSamples([0]))).toBeUndefined()
-  expect(estimateResolution(asSamples([0, -1, -0.5]))).toBeUndefined()
+  expect(estimateResolution(asSorted([0, 0, 0]))).toBeUndefined()
+  expect(estimateResolution(asSorted([0]))).toBeUndefined()
+  expect(estimateResolution(asSorted([-1, -0.5, 0]))).toBeUndefined()
 })
 
 test('Task.detectedResolution is undefined before run', () => {

--- a/test/subtract-timer-overhead-alignment.test.ts
+++ b/test/subtract-timer-overhead-alignment.test.ts
@@ -26,7 +26,7 @@ const makeStepProvider = (stepNs: number): TimestampProvider => {
   }
 }
 
-test('subtractTimerOverhead aligns isOverridden with samples in mixed runs', async () => {
+test('subtractTimerOverhead aligns overridden samples with measured ones in mixed runs', async () => {
   const iterations = 32
   const K = 100
   const stepNs = 1000

--- a/test/subtract-timer-overhead-alignment.test.ts
+++ b/test/subtract-timer-overhead-alignment.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from 'vitest'
+
+import type { TimestampProvider } from '../src/types'
+
+import { Bench } from '../src'
+import { nToMs } from '../src/utils'
+
+/**
+ * Deterministic provider where every back-to-back call pair yields a delta
+ * of exactly `stepNs` nanoseconds. Calibration converges on `stepNs / 1e6`
+ * ms; every measured raw `taskTime` equals that same overhead, so after
+ * `max(0, raw - Ĉ)` correction every measured sample becomes `0`.
+ * @param stepNs - the per-call increment in nanoseconds
+ * @returns a fresh provider with its own counter
+ */
+const makeStepProvider = (stepNs: number): TimestampProvider => {
+  let counter = 0
+  return {
+    fn: () => {
+      counter += 1
+      return counter * stepNs
+    },
+    fromMs: ms => ms * 1_000_000,
+    name: 'det-step',
+    toMs: nToMs,
+  }
+}
+
+test('subtractTimerOverhead aligns isOverridden with samples in mixed runs', async () => {
+  const iterations = 32
+  const K = 100
+  const stepNs = 1000
+  const stepMs = stepNs / 1_000_000
+  const bench = new Bench({
+    iterations,
+    retainSamples: true,
+    subtractTimerOverhead: true,
+    time: 0,
+    timestampProvider: makeStepProvider(stepNs),
+    warmup: false,
+  })
+  expect(bench.timerOverhead).toBe(stepMs)
+
+  let i = 0
+  bench.add('alternating', () => {
+    if ((i++ & 1) === 0) return { overriddenDuration: K }
+    return undefined
+  })
+  await bench.run()
+
+  const task = bench.getTask('alternating')
+  expect(task).toBeDefined()
+  if (!task) return
+  expect(task.result.state).toBe('completed')
+  if (task.result.state !== 'completed') return
+
+  const samples = task.result.latency.samples
+  expect(samples).toBeDefined()
+  if (!samples) return
+  expect(samples.length).toBe(iterations)
+  expect(samples.filter(s => s === K).length).toBe(iterations / 2)
+  expect(samples.filter(s => s === 0).length).toBe(iterations / 2)
+  expect(samples.every(s => s >= 0)).toBe(true)
+  expect(task.result.latency.min).toBe(0)
+  expect(task.result.latency.max).toBe(K)
+})
+
+test('subtractTimerOverhead alignment holds with the real timer', async () => {
+  const iterations = 32
+  const K = 0.0000001234567
+  const bench = new Bench({
+    iterations,
+    retainSamples: true,
+    subtractTimerOverhead: true,
+    time: 0,
+    warmup: false,
+  })
+  let i = 0
+  bench.add('alternating', () => {
+    if ((i++ & 1) === 0) return { overriddenDuration: K }
+    return undefined
+  })
+  await bench.run()
+
+  const task = bench.getTask('alternating')
+  if (task?.result.state !== 'completed') return
+  const samples = task.result.latency.samples
+  if (!samples) return
+  expect(samples.filter(s => s === K).length).toBe(iterations / 2)
+  expect(samples.filter(s => s !== K).every(s => s >= 0)).toBe(true)
+  expect(samples.filter(s => s !== K).length).toBe(iterations / 2)
+})

--- a/test/subtract-timer-overhead-overridden.test.ts
+++ b/test/subtract-timer-overhead-overridden.test.ts
@@ -26,8 +26,13 @@ test('subtractTimerOverhead does not modify samples returned via overriddenDurat
   expect(task.result.latency.max).toBeCloseTo(target, 5)
 })
 
-test('warning event is not dispatched for constant overriddenDuration when no real timer saturation', async () => {
-  const bench = new Bench({ iterations: 32, time: 0, warmup: false })
+test('warning event is not dispatched for fully-overridden constant duration (issue #10)', async () => {
+  const bench = new Bench({
+    iterations: 32,
+    subtractTimerOverhead: true,
+    time: 0,
+    warmup: false,
+  })
   let warningCount = 0
   bench.addEventListener('warning', () => {
     warningCount++
@@ -37,14 +42,11 @@ test('warning event is not dispatched for constant overriddenDuration when no re
   })
   await bench.run()
 
-  // 32 samples is below the n < 10 guard? No — 32 >= 10, so saturation
-  // detection runs. distinctCount=1 < 3 triggers criterion B → a warning is
-  // expected for a constant-duration task. The semantics is: any task whose
-  // measured distribution has < 3 distinct values is flagged as
-  // timer-saturated, including legitimate deterministic functions.
-  // This test documents that current behavior; if the project later filters
-  // overridden samples at the call site, it should be updated to expect 0.
-  expect(warningCount).toBeGreaterThanOrEqual(0)
+  // All 32 samples are overridden → measuredOnly is empty → no saturation
+  // detection runs → no warning. This is the issue #10 fix in action: the
+  // saturation heuristic only sees timer-measured samples, never user-supplied
+  // overriddenDuration values.
+  expect(warningCount).toBe(0)
 })
 
 test('detectedResolution is not affected by subtractTimerOverhead correction', async () => {

--- a/test/subtract-timer-overhead-overridden.test.ts
+++ b/test/subtract-timer-overhead-overridden.test.ts
@@ -49,7 +49,7 @@ test('warning event is not dispatched for fully-overridden constant duration (is
   expect(warningCount).toBe(0)
 })
 
-test('detectedResolution is not affected by subtractTimerOverhead correction', async () => {
+test('detectedResolution is undefined when every sample is overridden', async () => {
   const benchA = new Bench({
     iterations: 64,
     subtractTimerOverhead: false,
@@ -75,6 +75,6 @@ test('detectedResolution is not affected by subtractTimerOverhead correction', a
 
   const taskA = benchA.getTask('regex')
   const taskB = benchB.getTask('regex')
-  expect(taskA?.detectedResolution).toBe(0.001)
-  expect(taskB?.detectedResolution).toBe(0.001)
+  expect(taskA?.detectedResolution).toBeUndefined()
+  expect(taskB?.detectedResolution).toBeUndefined()
 })

--- a/test/subtract-timer-overhead-overridden.test.ts
+++ b/test/subtract-timer-overhead-overridden.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'vitest'
+
+import { Bench } from '../src'
+
+test('subtractTimerOverhead does not modify samples returned via overriddenDuration', async () => {
+  const target = 1
+  const bench = new Bench({
+    iterations: 32,
+    subtractTimerOverhead: true,
+    time: 0,
+    warmup: false,
+  })
+  bench.add('override-bench', () => {
+    return { overriddenDuration: target }
+  })
+  await bench.run()
+
+  const task = bench.getTask('override-bench')
+  expect(task).toBeDefined()
+  if (!task) return
+  expect(task.result.state).toBe('completed')
+  if (task.result.state !== 'completed') return
+
+  expect(task.result.latency.mean).toBeCloseTo(target, 5)
+  expect(task.result.latency.min).toBeCloseTo(target, 5)
+  expect(task.result.latency.max).toBeCloseTo(target, 5)
+})
+
+test('warning event is not dispatched for constant overriddenDuration when no real timer saturation', async () => {
+  const bench = new Bench({ iterations: 32, time: 0, warmup: false })
+  let warningCount = 0
+  bench.addEventListener('warning', () => {
+    warningCount++
+  })
+  bench.add('override-bench', () => {
+    return { overriddenDuration: 0.05 }
+  })
+  await bench.run()
+
+  // 32 samples is below the n < 10 guard? No — 32 >= 10, so saturation
+  // detection runs. distinctCount=1 < 3 triggers criterion B → a warning is
+  // expected for a constant-duration task. The semantics is: any task whose
+  // measured distribution has < 3 distinct values is flagged as
+  // timer-saturated, including legitimate deterministic functions.
+  // This test documents that current behavior; if the project later filters
+  // overridden samples at the call site, it should be updated to expect 0.
+  expect(warningCount).toBeGreaterThanOrEqual(0)
+})
+
+test('detectedResolution is not affected by subtractTimerOverhead correction', async () => {
+  const benchA = new Bench({
+    iterations: 64,
+    subtractTimerOverhead: false,
+    time: 100,
+    warmup: false,
+  })
+  const benchB = new Bench({
+    iterations: 64,
+    subtractTimerOverhead: true,
+    time: 100,
+    warmup: false,
+  })
+
+  benchA.add('regex', () => {
+    return { overriddenDuration: 0.001 }
+  })
+  benchB.add('regex', () => {
+    return { overriddenDuration: 0.001 }
+  })
+
+  await benchA.run()
+  await benchB.run()
+
+  const taskA = benchA.getTask('regex')
+  const taskB = benchB.getTask('regex')
+  expect(taskA?.detectedResolution).toBe(0.001)
+  expect(taskB?.detectedResolution).toBe(0.001)
+})

--- a/test/utils-detect-timer-saturation.test.ts
+++ b/test/utils-detect-timer-saturation.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'vitest'
+
+import type { Samples } from '../src/types'
+
+import { detectTimerSaturation } from '../src/utils'
+
+const asSamples = (arr: number[]): Samples => arr as unknown as Samples
+
+test('detectTimerSaturation returns false for n below the minimum threshold', () => {
+  expect(detectTimerSaturation(asSamples([1]), 0)).toBe(false)
+  expect(
+    detectTimerSaturation(asSamples([1, 1, 1, 1, 1, 1, 1, 1, 1]), 0)
+  ).toBe(false)
+})
+
+test('detectTimerSaturation flags more than half zero samples (criterion A)', () => {
+  expect(
+    detectTimerSaturation(asSamples([0, 0, 0, 0, 0, 0, 1, 2, 3, 4]), 0)
+  ).toBe(true)
+})
+
+test('detectTimerSaturation does not flag exactly half zero samples', () => {
+  expect(
+    detectTimerSaturation(asSamples([0, 0, 0, 0, 0, 1, 2, 3, 4, 5]), 1)
+  ).toBe(false)
+})
+
+test('detectTimerSaturation flags degenerate distinct counts (criterion B)', () => {
+  expect(
+    detectTimerSaturation(asSamples(new Array<number>(64).fill(1)), 0)
+  ).toBe(true)
+  const halfHalf = new Array<number>(500)
+    .fill(1)
+    .concat(new Array<number>(500).fill(2))
+  expect(detectTimerSaturation(asSamples(halfHalf), 0.5)).toBe(true)
+})
+
+test('detectTimerSaturation flags zero MAD with more than 100 samples (criterion C)', () => {
+  const arr: number[] = []
+  for (let i = 0; i < 120; i++) arr.push(5)
+  for (let i = 0; i < 80; i++) arr.push((i % 10) + 1)
+  arr.sort((a, b) => a - b)
+  expect(detectTimerSaturation(asSamples(arr), 0)).toBe(true)
+})
+
+test('detectTimerSaturation does not flag healthy spread samples', () => {
+  const arr: number[] = []
+  let seed = 42
+  for (let i = 0; i < 500; i++) {
+    seed = (seed * 1664525 + 1013904223) >>> 0
+    arr.push(50 + ((seed >>> 0) / 0xffffffff - 0.5) * 10)
+  }
+  arr.sort((a, b) => a - b)
+  expect(detectTimerSaturation(asSamples(arr), 1.5)).toBe(false)
+})

--- a/test/utils-detect-timer-saturation.test.ts
+++ b/test/utils-detect-timer-saturation.test.ts
@@ -95,3 +95,29 @@ test('classifyTimerSaturation returns undefined for healthy spread samples', () 
   arr.sort((a, b) => a - b)
   expect(classifyTimerSaturation(asSorted(arr), 1.5)).toBeUndefined()
 })
+
+const zeroMadSamples = (medianRepeats: number): number[] => {
+  const arr: number[] = new Array<number>(medianRepeats).fill(5)
+  for (let i = 0; i < 40; i++) arr.push(100 + i)
+  return arr.sort((a, b) => a - b)
+}
+
+test("classifyTimerSaturation withholds 'zero-mad' at the n = 100 boundary", () => {
+  expect(classifyTimerSaturation(asSorted(zeroMadSamples(60)), 0)).toBeUndefined()
+})
+
+test("classifyTimerSaturation fires 'zero-mad' just past the boundary (n = 101)", () => {
+  expect(classifyTimerSaturation(asSorted(zeroMadSamples(61)), 0)).toBe('zero-mad')
+})
+
+test('classifyTimerSaturation applies the distinct threshold ceiling of 10 at n = 10000', () => {
+  const nineDistinct = Array.from({ length: 10000 }, (_, i) => (i % 9) + 1).sort(
+    (a, b) => a - b
+  )
+  expect(classifyTimerSaturation(asSorted(nineDistinct), 1)).toBe('low-distinct')
+
+  const tenDistinct = Array.from({ length: 10000 }, (_, i) => (i % 10) + 1).sort(
+    (a, b) => a - b
+  )
+  expect(classifyTimerSaturation(asSorted(tenDistinct), 1)).toBeUndefined()
+})

--- a/test/utils-detect-timer-saturation.test.ts
+++ b/test/utils-detect-timer-saturation.test.ts
@@ -1,38 +1,39 @@
 import { expect, test } from 'vitest'
 
-import type { Samples } from '../src/types'
+import type { SortedSamples } from '../src/types'
 
 import { detectTimerSaturation } from '../src/utils'
 
-const asSamples = (arr: number[]): Samples => arr as unknown as Samples
+const asSorted = (arr: number[]): SortedSamples =>
+  arr as unknown as SortedSamples
 
 test('detectTimerSaturation returns false for n below the minimum threshold', () => {
-  expect(detectTimerSaturation(asSamples([1]), 0)).toBe(false)
+  expect(detectTimerSaturation(asSorted([1]), 0)).toBe(false)
   expect(
-    detectTimerSaturation(asSamples([1, 1, 1, 1, 1, 1, 1, 1, 1]), 0)
+    detectTimerSaturation(asSorted([1, 1, 1, 1, 1, 1, 1, 1, 1]), 0)
   ).toBe(false)
 })
 
 test('detectTimerSaturation flags more than half zero samples (criterion A)', () => {
   expect(
-    detectTimerSaturation(asSamples([0, 0, 0, 0, 0, 0, 1, 2, 3, 4]), 0)
+    detectTimerSaturation(asSorted([0, 0, 0, 0, 0, 0, 1, 2, 3, 4]), 0)
   ).toBe(true)
 })
 
 test('detectTimerSaturation does not flag exactly half zero samples', () => {
   expect(
-    detectTimerSaturation(asSamples([0, 0, 0, 0, 0, 1, 2, 3, 4, 5]), 1)
+    detectTimerSaturation(asSorted([0, 0, 0, 0, 0, 1, 2, 3, 4, 5]), 1)
   ).toBe(false)
 })
 
 test('detectTimerSaturation flags degenerate distinct counts (criterion B)', () => {
   expect(
-    detectTimerSaturation(asSamples(new Array<number>(64).fill(1)), 0)
+    detectTimerSaturation(asSorted(new Array<number>(64).fill(1)), 0)
   ).toBe(true)
   const halfHalf = new Array<number>(500)
     .fill(1)
     .concat(new Array<number>(500).fill(2))
-  expect(detectTimerSaturation(asSamples(halfHalf), 0.5)).toBe(true)
+  expect(detectTimerSaturation(asSorted(halfHalf), 0.5)).toBe(true)
 })
 
 test('detectTimerSaturation flags zero MAD with more than 100 samples (criterion C)', () => {
@@ -40,7 +41,7 @@ test('detectTimerSaturation flags zero MAD with more than 100 samples (criterion
   for (let i = 0; i < 120; i++) arr.push(5)
   for (let i = 0; i < 80; i++) arr.push((i % 10) + 1)
   arr.sort((a, b) => a - b)
-  expect(detectTimerSaturation(asSamples(arr), 0)).toBe(true)
+  expect(detectTimerSaturation(asSorted(arr), 0)).toBe(true)
 })
 
 test('detectTimerSaturation does not flag healthy spread samples', () => {
@@ -51,5 +52,5 @@ test('detectTimerSaturation does not flag healthy spread samples', () => {
     arr.push(50 + ((seed >>> 0) / 0xffffffff - 0.5) * 10)
   }
   arr.sort((a, b) => a - b)
-  expect(detectTimerSaturation(asSamples(arr), 1.5)).toBe(false)
+  expect(detectTimerSaturation(asSorted(arr), 1.5)).toBe(false)
 })

--- a/test/utils-detect-timer-saturation.test.ts
+++ b/test/utils-detect-timer-saturation.test.ts
@@ -2,7 +2,10 @@ import { expect, test } from 'vitest'
 
 import type { SortedSamples } from '../src/types'
 
-import { detectTimerSaturation } from '../src/utils'
+import {
+  classifyTimerSaturation,
+  detectTimerSaturation,
+} from '../src/utils'
 
 const asSorted = (arr: number[]): SortedSamples =>
   arr as unknown as SortedSamples
@@ -53,4 +56,42 @@ test('detectTimerSaturation does not flag healthy spread samples', () => {
   }
   arr.sort((a, b) => a - b)
   expect(detectTimerSaturation(asSorted(arr), 1.5)).toBe(false)
+})
+
+test('classifyTimerSaturation returns undefined for n below the minimum threshold', () => {
+  expect(classifyTimerSaturation(asSorted([1]), 0)).toBeUndefined()
+  expect(
+    classifyTimerSaturation(asSorted([1, 1, 1, 1, 1, 1, 1, 1, 1]), 0)
+  ).toBeUndefined()
+})
+
+test("classifyTimerSaturation returns 'zero-dominated' for criterion A", () => {
+  expect(
+    classifyTimerSaturation(asSorted([0, 0, 0, 0, 0, 0, 1, 2, 3, 4]), 0)
+  ).toBe('zero-dominated')
+})
+
+test("classifyTimerSaturation returns 'low-distinct' for criterion B", () => {
+  expect(
+    classifyTimerSaturation(asSorted(new Array<number>(64).fill(1)), 0)
+  ).toBe('low-distinct')
+})
+
+test("classifyTimerSaturation returns 'zero-mad' for criterion C", () => {
+  const arr: number[] = []
+  for (let i = 0; i < 120; i++) arr.push(5)
+  for (let i = 0; i < 80; i++) arr.push((i % 10) + 1)
+  arr.sort((a, b) => a - b)
+  expect(classifyTimerSaturation(asSorted(arr), 0)).toBe('zero-mad')
+})
+
+test('classifyTimerSaturation returns undefined for healthy spread samples', () => {
+  const arr: number[] = []
+  let seed = 42
+  for (let i = 0; i < 500; i++) {
+    seed = (seed * 1664525 + 1013904223) >>> 0
+    arr.push(50 + ((seed >>> 0) / 0xffffffff - 0.5) * 10)
+  }
+  arr.sort((a, b) => a - b)
+  expect(classifyTimerSaturation(asSorted(arr), 1.5)).toBeUndefined()
 })

--- a/test/warning-event-reason.test.ts
+++ b/test/warning-event-reason.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest'
+
+import type { TimerSaturationReason, TimestampProvider } from '../src/types'
+
+import { Bench } from '../src'
+import { mToMs } from '../src/utils'
+
+const fixedZeroProvider: TimestampProvider = {
+  fn: () => 0,
+  fromMs: mToMs,
+  name: 'fixed-zero',
+  toMs: mToMs,
+}
+
+test("warning event carries reason 'zero-dominated' for a constant-zero timer", async () => {
+  const bench = new Bench({
+    iterations: 64,
+    time: 0,
+    timestampProvider: fixedZeroProvider,
+    warmup: false,
+  })
+  let received: TimerSaturationReason | undefined
+  bench.addEventListener('warning', evt => {
+    received = evt.reason
+  })
+  bench.add('zero-task', () => {
+    // noop
+  })
+  await bench.run()
+  expect(received).toBe('zero-dominated')
+})
+
+test('non-warning events expose reason as undefined', async () => {
+  const bench = new Bench({ iterations: 8, time: 0, warmup: false })
+  let cycleReason: unknown = 'untouched'
+  bench.addEventListener('cycle', evt => {
+    cycleReason = evt.reason
+  })
+  bench.add('noop', () => {
+    // noop
+  })
+  await bench.run()
+  expect(cycleReason).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

Three cooperating timer diagnostics for sub-microsecond benchmarking, integrated in a single coherent code path:

1. **`subtractTimerOverhead`** — opt-in calibration of one timestamp provider call cost `Ĉ`, applied as `max(0, raw - Ĉ)` to non-overridden samples before statistics.
2. **`'warning'` event** — dispatched on both `Bench` and `Task` when a `Task`'s measured samples are dominated by the timer resolution. Carries a `TimerSaturationReason` payload (`'zero-dominated' | 'low-distinct' | 'zero-mad'`).
3. **`Task.detectedResolution`** — populated after each run with the smallest reproducibly observed positive sample among timer-measured samples.

Replaces #568, #569 and #570: their naïve composition would have the diagnostics operate on the corrected-and-clamped sample set, producing artificially small resolution estimates and false-positive saturation warnings.

## Public API

```ts
import { Bench } from 'tinybench'

// Per-Bench (opt-in, default false)
const bench = new Bench({ subtractTimerOverhead: true })
bench.subtractTimerOverhead  // readonly boolean
bench.timerOverhead          // number | undefined — calibrated Ĉ in ms

// Per-Task diagnostic
const task = bench.getTask('foo')
task.detectedResolution      // number | undefined

// Saturation warning event with typed reason
bench.addEventListener('warning', evt => {
  evt.task    // Task
  evt.reason  // TimerSaturationReason | undefined
})

// Standalone helpers
import {
  calibrateTimerOverhead,
  classifyTimerSaturation,    // → TimerSaturationReason | undefined
  detectTimerSaturation,      // boolean wrapper around classifyTimerSaturation
  estimateResolution,
  medianAbsoluteDeviation,    // mad statistic from a sorted sample
} from 'tinybench'

// Timestamp provider objects (pass to calibrateTimerOverhead)
import {
  hrtimeNowTimestampProvider,
  performanceNowTimestampProvider,
} from 'tinybench'

import type {
  CalibrateTimerOverheadOptions,
  TimerOverheadEstimatorKind,  // 'median' | 'min' | 'p05'
  TimerSaturationReason,
} from 'tinybench'
```

## `Task#processRunResult` ordering (cross-cutting fix)

`isOverridden[]` is collected in lockstep with `latencySamples[]` during measurement. The phase ordering preserves the alignment invariant and isolates user-supplied `overriddenDuration` values from timer diagnostics:

1. **Apply overhead correction** in-place on the collection-order array (skipping overridden indices). Alignment intact.
2. **Build a `measuredOnly` view** by filtering out overridden indices, before any sort.
3. **Sort** the working `latencySamples` array.
4. **`computeStatistics`** on the sorted (possibly corrected) samples.
5. **`estimateResolution` + `classifyTimerSaturation`** on the sorted measured-only subset (`estimateResolution` requires ascending-sorted input). With no overrides the subset is `latencySamples` itself; otherwise the filtered view is sorted first. An all-overridden run yields `undefined` resolution and no warning.
6. **Dispatch** the `'warning'` event (carrying the reason, when a criterion fired), then `'cycle'` and `'complete'`.

`isOverridden` is allocated unconditionally so the measured-only filter is also active when `subtractTimerOverhead: false` (covers `overriddenDuration` users without overhead correction).

## Constraints

- `subtractTimerOverhead` + `concurrency: 'task'` is rejected. Asserted at construction **and** re-checked at the start of `Bench.run()` to guard against untyped (JS-side) mutation of the `readonly` `concurrency` field after construction.
- When the timer is too coarse to resolve the call cost — fewer than half the calibration pairs produce a positive delta (`C < R / 2`, e.g. a `Date.now`-class timer with `>= 1 ms` resolution) — calibration returns `0` and the option becomes a no-op.

## Risk

- **Runtime:** opt-in for behaviour-changing pieces. Default-options benchmarks behave identically.
- **TypeScript:** `BenchEvents` widened with `'warning'`; exhaustive `switch` consumers under `noFallthroughCasesInSwitch` need a `case 'warning':` arm. `BenchLike.timerOverhead` is now `readonly` and optional. New types `TimerSaturationReason`, `TimerOverheadEstimatorKind`, `CalibrateTimerOverheadOptions`. New runtime exports `calibrateTimerOverhead`, `classifyTimerSaturation`, `detectTimerSaturation`, `estimateResolution`, `medianAbsoluteDeviation`, `hrtimeNowTimestampProvider`, `performanceNowTimestampProvider`.
- **Bundle:** `+0.7 kB` gzipped vs main. The pre-existing `size-limit` budget of 12 kB is already exceeded on main (14.15 kB) — this PR does not change that situation.
- **No new runtime dependency.**

## JSDoc honesty

The `subtractTimerOverhead` JSDoc describes the `max(0, x)` clamp explicitly:

- Two regimes (clean-shift `X >> Ĉ` vs sub-overhead `X ≈ Ĉ`)
- `rme` deterministically inflates by factor `M / (M − Ĉ)` whenever `Ĉ > 0`
- In the sub-overhead regime, `p50`, `mad`, `aad` collapse to `0` once cumulative mass at `≤ Ĉ` reaches the relevant quantile
- Three observable consequences of the clamp (`latency.min == 0`, throughput-mean substitution, `'zero-dominated'` criterion ambiguity)

## Verification

- `pnpm typecheck` clean
- `pnpm lint` clean
- `pnpm test` — **237 tests pass** across **64 test files**
- `pnpm build` — `dist` generated cleanly

