### PR TITLE
fix: export `mToNs` used in README `console.table` example

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,4 +37,4 @@ export type {
   TimestampProvider,
   TimestampValue,
 } from './types'
-export { formatNumber, hrtimeNow, performanceNow as now, nToMs } from './utils'
+export { formatNumber, hrtimeNow, mToNs, performanceNow as now, nToMs } from './utils'


### PR DESCRIPTION
Closes #591.

The [`console.table()` customization example](https://github.com/tinylibs/tinybench/blob/main/README.md#convert-task-results-for-consoletable) imports `mToNs` from `tinybench`, but the symbol was never re-exported from the package entry point — only its inverse `nToMs` was.

`mToNs` is already defined and exported from `src/utils.ts`; this PR adds it to the `src/index.ts` barrel, preserving the natural alphabetical ordering enforced by `perfectionist/recommended-natural`.