### PR TITLE
docs: add FAQ.md (measurement precision, JIT deopt, cross-tool differences)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -3,14 +3,18 @@
 ## How do I deal with measurement precision issues?
 
 If a task runs faster than the resolution of the timer your runtime provides,
-individual samples can measure as zero duration, which produces unreliable
-results (high margin of error, skewed latency). The resolution of the default
-timer varies by runtime and platform.
+individual samples can measure as zero duration, which skews the reported
+latency. Tinybench flags this directly: when a task's samples are dominated by
+the timer resolution it dispatches a `'warning'` event and exposes the observed
+`detectedResolution` on the task (see the README
+[Timer Diagnostics](./README.md#timer-diagnostics) section). The resolution of
+the default timer varies by runtime and platform.
 
 Tinybench lets you choose a timestamp provider via the `timestampProvider`
 option, which accepts a `TimestampProvider` object or the shorthands
 `hrtimeNow`, `performanceNow`, `bunNanoseconds` (when running on Bun), or `auto`
-(to let Tinybench pick the best available provider for the current runtime):
+(to let Tinybench pick the most precise available provider for the current
+runtime):
 
 ```ts
 import { Bench } from 'tinybench'

--- a/FAQ.md
+++ b/FAQ.md
@@ -4,9 +4,9 @@
 
 If a task runs faster than the resolution of the timer your runtime provides,
 individual samples can measure as zero duration, which skews the reported
-latency. Tinybench flags this directly: when a task's samples are dominated by
-the timer resolution it dispatches a `'warning'` event and exposes the observed
-`detectedResolution` on the task (see the README
+latency. Tinybench surfaces this directly: every run exposes the observed
+`detectedResolution` on the task, and when a task's samples are dominated by the
+timer resolution it also dispatches a `'warning'` event (see the README
 [Timer Diagnostics](./README.md#timer-diagnostics) section). The resolution of
 the default timer varies by runtime and platform.
 
@@ -25,12 +25,17 @@ const bench = new Bench({
 ```
 
 See the README [Timestamp Providers](./README.md#timestamp-providers) section
-for the full list and custom-provider setup.
+for the full list and custom-provider setup. To supply a plain millisecond
+clock without building a `TimestampProvider`, set the `now` option instead; it
+is converted to a provider internally and cannot be combined with
+`timestampProvider`.
 
 Beyond picking a higher-resolution provider, you can increase the benchmark
-`time` so more samples are collected (improving statistical confidence), and
-inspect the reported relative margin of error (`rme`) — a very high `rme` often
-signals that the task executes faster than the timer can measure accurately.
+`time` so more samples are collected (improving statistical confidence). The
+most reliable saturation signal is the `'warning'` event and
+`detectedResolution` (see [Timer Diagnostics](./README.md#timer-diagnostics));
+the relative margin of error (`rme`) is only a soft hint — a saturated task
+can report either a very high or a very low `rme`, so do not rely on it alone.
 Manually looping a fast function to "amplify" its duration can lift a sample
 above the timer resolution, but it adds loop overhead and changes what you
 measure; a more precise timestamp provider is usually the cleaner fix.
@@ -45,9 +50,10 @@ on the engine). During benchmarking this can show up as sudden latency spikes.
 
 Common causes include type instability (argument types changing between
 iterations) and dynamic property access or function reassignment that prevents
-inlining, and — in browsers — having DevTools open, which can degrade JIT
-performance. Garbage-collection pauses are a separate source of latency spikes
-(not a deopt) that can likewise inflate variance.
+inlining. Garbage-collection pauses are a separate source of latency spikes
+(not a deopt) that can likewise inflate variance, and — in browsers — having
+DevTools open adds overhead and can disable some JIT optimizations rather than
+being a deopt itself.
 
 Tinybench reports statistical indicators (standard deviation, variance,
 percentiles, margin of error) that help you spot outliers caused by deopts. If

--- a/FAQ.md
+++ b/FAQ.md
@@ -4,9 +4,10 @@
 
 If a task runs faster than the resolution of the timer your runtime provides,
 individual samples can measure as zero duration, which skews the reported
-latency. Tinybench surfaces this directly: every run exposes the observed
-`detectedResolution` on the task, and when a task's samples are dominated by the
-timer resolution it also dispatches a `'warning'` event (see the README
+latency. Tinybench surfaces this directly: after each run the task exposes the
+observed `detectedResolution` (or `undefined` when no positive timer sample was
+measured), and when a task's samples are dominated by the timer resolution it
+also dispatches a `'warning'` event (see the README
 [Timer Diagnostics](./README.md#timer-diagnostics) section). The resolution of
 the default timer varies by runtime and platform.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -15,18 +15,9 @@ Tinybench lets you choose a timestamp provider via the `timestampProvider`
 option, which accepts a `TimestampProvider` object or the shorthands
 `hrtimeNow`, `performanceNow`, `bunNanoseconds` (when running on Bun), or `auto`
 (to let Tinybench pick the most precise available provider for the current
-runtime):
-
-```ts
-import { Bench } from 'tinybench'
-
-const bench = new Bench({
-  timestampProvider: 'hrtimeNow', // or 'performanceNow', 'bunNanoseconds', 'auto'
-})
-```
-
-See the README [Timestamp Providers](./README.md#timestamp-providers) section
-for the full list and custom-provider setup. To supply a plain millisecond
+runtime). See the README
+[Timestamp Providers](./README.md#timestamp-providers) section for the full
+list, an example, and custom-provider setup. To supply a plain millisecond
 clock without building a `TimestampProvider`, set the `now` option instead; it
 is converted to a provider internally and cannot be combined with
 `timestampProvider`.

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,68 @@
+# Frequently Asked Questions
+
+## How do I deal with measurement precision issues?
+
+If a task runs faster than the resolution of the timer your runtime provides,
+individual samples can measure as zero duration, which produces unreliable
+results (high margin of error, skewed latency). The resolution of the default
+timer varies by runtime and platform.
+
+Tinybench lets you choose a timestamp provider via the `timestampProvider`
+option, which accepts a `TimestampProvider` object or the shorthands
+`hrtimeNow`, `performanceNow`, `bunNanoseconds` (when running on Bun), or `auto`
+(to let Tinybench pick the best available provider for the current runtime):
+
+```ts
+import { Bench } from 'tinybench'
+
+const bench = new Bench({
+  timestampProvider: 'hrtimeNow', // or 'performanceNow', 'bunNanoseconds', 'auto'
+})
+```
+
+Beyond picking a higher-resolution provider, you can increase the benchmark
+`time` so more samples are collected (improving statistical confidence), and
+inspect the reported margin of error (`rme`) — a very high `rme` often signals
+that the task executes faster than the timer can measure accurately. Looping a
+fast function to "amplify" its duration does not fix the underlying precision
+problem; prefer a more precise timestamp provider.
+
+## What is JS JIT de-optimization?
+
+JavaScript engines (V8, SpiderMonkey, JavaScriptCore) compile hot code paths
+just-in-time (JIT). JIT de-optimization (a "deopt") happens when the engine
+discards an optimized code path and falls back to slower, interpreted
+execution. During benchmarking this can show up as sudden latency spikes.
+
+Common causes include type instability (argument types changing between
+iterations), garbage-collection pauses interrupting the measured region,
+dynamic property access or function reassignment that prevents inlining, and —
+in browsers — having DevTools open, which disables many JIT optimizations.
+
+Tinybench reports statistical indicators (standard deviation, variance,
+percentiles, margin of error) that help you spot outliers caused by deopts. If
+you see high variance, try running the benchmark multiple times and comparing
+results, ensuring warmup iterations run before measurement, and (in browsers)
+closing DevTools and running in a production-like configuration.
+
+## Why do my results differ from another benchmarking tool?
+
+Differences between benchmarking tools are expected and do not necessarily
+indicate a bug. Common reasons:
+
+- **Different timing APIs.** Tools may use `Date.now()`, `performance.now()`,
+  or `process.hrtime.bigint()`, each with different resolution and overhead.
+- **Different measurement methodology.** Some tools measure a single iteration;
+  Tinybench collects many samples over a configurable `time` window and reports
+  statistically analyzed latency and throughput (mean, median, p75/p99,
+  standard deviation, margin of error).
+- **Different statistics.** Tools aggregate differently (arithmetic mean,
+  geometric mean, median, …). Tinybench reports both average and median (p50).
+- **Warmup handling.** Some tools include warmup runs in their measurements;
+  the first samples Tinybench collects may include JIT warmup cost.
+- **Overhead.** Every tool introduces its own measurement overhead (loop,
+  function call, event dispatch). Tinybench is small, but not zero-overhead.
+
+When comparing across tools, focus on the **relative** difference (is
+implementation A faster than B?) rather than the absolute operations-per-second
+numbers, and run the comparison on the same machine in the same environment.

--- a/FAQ.md
+++ b/FAQ.md
@@ -20,30 +20,37 @@ const bench = new Bench({
 })
 ```
 
+See the README [Timestamp Providers](./README.md#timestamp-providers) section
+for the full list and custom-provider setup.
+
 Beyond picking a higher-resolution provider, you can increase the benchmark
 `time` so more samples are collected (improving statistical confidence), and
-inspect the reported margin of error (`rme`) — a very high `rme` often signals
-that the task executes faster than the timer can measure accurately. Looping a
-fast function to "amplify" its duration does not fix the underlying precision
-problem; prefer a more precise timestamp provider.
+inspect the reported relative margin of error (`rme`) — a very high `rme` often
+signals that the task executes faster than the timer can measure accurately.
+Manually looping a fast function to "amplify" its duration can lift a sample
+above the timer resolution, but it adds loop overhead and changes what you
+measure; a more precise timestamp provider is usually the cleaner fix.
 
 ## What is JS JIT de-optimization?
 
 JavaScript engines (V8, SpiderMonkey, JavaScriptCore) compile hot code paths
 just-in-time (JIT). JIT de-optimization (a "deopt") happens when the engine
-discards an optimized code path and falls back to slower, interpreted
-execution. During benchmarking this can show up as sudden latency spikes.
+discards an optimized code path and falls back to a lower, unoptimized
+execution tier (a bytecode interpreter or a less-optimized JIT tier, depending
+on the engine). During benchmarking this can show up as sudden latency spikes.
 
 Common causes include type instability (argument types changing between
-iterations), garbage-collection pauses interrupting the measured region,
-dynamic property access or function reassignment that prevents inlining, and —
-in browsers — having DevTools open, which disables many JIT optimizations.
+iterations) and dynamic property access or function reassignment that prevents
+inlining, and — in browsers — having DevTools open, which can degrade JIT
+performance. Garbage-collection pauses are a separate source of latency spikes
+(not a deopt) that can likewise inflate variance.
 
 Tinybench reports statistical indicators (standard deviation, variance,
 percentiles, margin of error) that help you spot outliers caused by deopts. If
 you see high variance, try running the benchmark multiple times and comparing
-results, ensuring warmup iterations run before measurement, and (in browsers)
-closing DevTools and running in a production-like configuration.
+results, keeping warmup enabled (the default; tunable via `warmupIterations` /
+`warmupTime`), and (in browsers) closing DevTools and running in a
+production-like configuration.
 
 ## Why do my results differ from another benchmarking tool?
 
@@ -58,8 +65,10 @@ indicate a bug. Common reasons:
   standard deviation, margin of error).
 - **Different statistics.** Tools aggregate differently (arithmetic mean,
   geometric mean, median, …). Tinybench reports both average and median (p50).
-- **Warmup handling.** Some tools include warmup runs in their measurements;
-  the first samples Tinybench collects may include JIT warmup cost.
+- **Warmup handling.** Tools differ in whether they warm up before measuring.
+  Tinybench warms up by default (`warmup`, on by default) in a separate phase
+  excluded from the reported statistics; disabling it (`warmup: false`) lets the
+  first measured samples include JIT warmup cost.
 - **Overhead.** Every tool introduces its own measurement overhead (loop,
   function call, event dispatch). Tinybench is small, but not zero-overhead.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ More usage examples can be found in the [examples](./examples/) directory.
 
 ## Docs
 
+### [FAQ](./FAQ.md)
+
 ### [`Bench`](https://tinylibs.github.io/tinybench/classes/Bench.html)
 
 ### [`Task`](https://tinylibs.github.io/tinybench/classes/Task.html)


### PR DESCRIPTION
## Summary

Closes #190 — adds a `FAQ.md` at the repo root covering the three topics in the issue's checklist:

1. **How to deal with measurement precision issues** — timer resolution varies by runtime; use the `timestampProvider` shorthands (`hrtimeNow`/`performanceNow`/`bunNanoseconds`/`auto`), increase `time`, and watch the `rme`.
2. **What is JS JIT de-optimization** — what deopt is, common causes during benchmarking (type instability, GC, DevTools), and how Tinybench's statistics surface it.
3. **Why results differ from another benchmarking tool** — different timing APIs, methodology, statistics, warmup handling, and overhead; focus on relative rather than absolute numbers.

The content is grounded in the README's existing documentation of `timestampProvider` and the `time` option, and the issue author (@jerome-benoit) explicitly invited a PR for this in #143.

## AI usage

An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

Closes #190