### PR TITLE
docs(examples): add convert() callback example for bench.table()

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -11,6 +11,8 @@
     "all": "run-s example:*",
     "example:simple": "tsx src/simple.ts",
     "simple:dev": "tsx --watch src/simple.ts",
+    "example:convert-table": "tsx src/convert-table.ts",
+    "convert-table:dev": "tsx --watch src/convert-table.ts",
     "example:simple-gc": "tsx --expose_gc src/simple-gc.ts",
     "simple-gc:dev": "tsx --watch --expose_gc src/simple-gc.ts",
     "example:simple-bun": "bun run src/simple-bun.ts"

--- a/examples/src/convert-table.ts
+++ b/examples/src/convert-table.ts
@@ -7,11 +7,13 @@ import {
 } from '../../src'
 
 // A custom converter for `bench.table()` that renders a compact,
-// latency-only view — omitting the throughput columns the default converter
-// includes. Pass any function with the `ConsoleTableConverter` signature to
-// `bench.table()` to customize the rows `console.table` prints.
+// latency-only view — omitting the throughput columns (and, for errored
+// tasks, the stack trace) the default converter includes. Pass any function
+// with the `ConsoleTableConverter` signature to `bench.table()` to customize
+// the rows `console.table` prints.
 const compactConverter: ConsoleTableConverter = (task: Task): Record<string, number | string> => {
   const state = task.result.state
+  /* eslint-disable perfectionist/sort-objects */
   return {
     'Task name': task.name,
     ...(state === 'aborted-with-statistics' || state === 'completed'
@@ -30,7 +32,11 @@ const compactConverter: ConsoleTableConverter = (task: Task): Record<string, num
         : {
             Error: task.result.error.message,
           }),
+    ...(state === 'aborted-with-statistics' && {
+      Remarks: state,
+    }),
   }
+  /* eslint-enable perfectionist/sort-objects */
 }
 
 const bench = new Bench({ name: 'compact table benchmark', time: 100 })
@@ -48,3 +54,12 @@ await bench.run()
 
 console.log(bench.name)
 console.table(bench.table(compactConverter))
+
+// Output:
+// compact table benchmark
+// ┌─────────┬───────────────┬───────────────────┬────────────────────┬─────────┐
+// │ (index) │ Task name     │ Latency avg (ns)  │ Latency med (ns)   │ Samples │
+// ├─────────┼───────────────┼───────────────────┼────────────────────┼─────────┤
+// │ 0       │ 'faster task' │ '1050.9 ± 0.57%'  │ '958.00 ± 208.00'  │ 95158   │
+// │ 1       │ 'slower task' │ '1156202 ± 3.19%' │ '1158875 ± 4750.0' │ 87      │
+// └─────────┴───────────────┴───────────────────┴────────────────────┴─────────┘

--- a/examples/src/convert-table.ts
+++ b/examples/src/convert-table.ts
@@ -1,0 +1,50 @@
+import {
+  Bench,
+  type ConsoleTableConverter,
+  formatNumber,
+  mToNs,
+  type Task,
+} from '../../src'
+
+// A custom converter for `bench.table()` that renders a compact,
+// latency-only view — omitting the throughput columns the default converter
+// includes. Pass any function with the `ConsoleTableConverter` signature to
+// `bench.table()` to customize the rows `console.table` prints.
+const compactConverter: ConsoleTableConverter = (task: Task): Record<string, number | string> => {
+  const state = task.result.state
+  return {
+    'Task name': task.name,
+    ...(state === 'aborted-with-statistics' || state === 'completed'
+      ? {
+          'Latency avg (ns)': `${formatNumber(mToNs(task.result.latency.mean))} \xb1 ${task.result.latency.rme.toFixed(2)}%`,
+          'Latency med (ns)': `${formatNumber(mToNs(task.result.latency.p50))} \xb1 ${formatNumber(mToNs(task.result.latency.mad))}`,
+          Samples: task.result.latency.samplesCount,
+        }
+      : state !== 'errored'
+        ? {
+            'Latency avg (ns)': 'N/A',
+            'Latency med (ns)': 'N/A',
+            Samples: 'N/A',
+            Remarks: state,
+          }
+        : {
+            Error: task.result.error.message,
+          }),
+  }
+}
+
+const bench = new Bench({ name: 'compact table benchmark', time: 100 })
+
+bench
+  .add('faster task', () => {
+    console.log('I am faster')
+  })
+  .add('slower task', async () => {
+    await new Promise(resolve => setTimeout(resolve, 1)) // we wait 1ms :)
+    console.log('I am slower')
+  })
+
+await bench.run()
+
+console.log(bench.name)
+console.table(bench.table(compactConverter))

--- a/examples/src/convert-table.ts
+++ b/examples/src/convert-table.ts
@@ -7,7 +7,7 @@ import {
 } from '../../src'
 
 // A custom converter for `bench.table()` that renders a compact,
-// latency-only view — omitting the throughput columns (and, for errored
+// latency-focused view — omitting the throughput columns (and, for errored
 // tasks, the stack trace) the default converter includes. Pass any function
 // with the `ConsoleTableConverter` signature to `bench.table()` to customize
 // the rows `console.table` prints.


### PR DESCRIPTION
## Summary

Closes #183 — adds a runnable example showing how to use the `convert()` callback of `bench.table()` to customize the result table.

**`examples/src/convert-table.ts`** — a `compactConverter` (`ConsoleTableConverter`) that renders a latency-only table (omitting the throughput columns the default converter includes), mirroring the existing `examples/src/simple.ts` structure (imports from `../../src`, top-level await, `console.table(bench.table(...))`) and the `defaultConverter` shown in the README. Handles all task states (`completed`, `aborted-with-statistics`, `errored`, other).

**`examples/package.json`** — adds `example:convert-table` and `convert-table:dev` scripts following the existing `example:*` / `*:dev` naming convention.

Run with `cd examples && pnpm install && pnpm example:convert-table`.

## AI usage

An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

Closes #183