### PR TITLE
fix(ci): always run documentation commit on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,6 @@ jobs:
           pnpm typedoc
 
       - name: Commit and push changes
-        if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         env:
           COMMIT_MESSAGE: 'docs: publish documentation'
           COMMIT_AUTHOR: Documentation Bot


### PR DESCRIPTION
## Summary

The `publish-documentation` job stopped committing the generated TypeDoc since **v6.0.3**: the "Commit and push changes" step is silently `skipped` on every release.

## Root cause

The step's guard compares `github.ref` against `refs/heads/<default_branch>`:

```yaml
if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
```

But this workflow triggers **only on tag pushes** (`on: push: tags: ['v*']`), so `github.ref` is always `refs/tags/vX.Y.Z` and never a branch ref → the condition can **never** be true → step skipped.

Introduced by `36fa8b6` (*"fix(ci): use format() in workflow conditional to avoid literal text warning"*, first shipped in v6.0.3). Before that commit the guard was written as mixed `${{ }}` interpolation inside literal text:

```yaml
if: github.ref == 'refs/heads/${{ github.event.repository.default_branch }}'
```

GitHub Actions evaluates that as a **non-empty literal string** (always truthy), so the step ran *unconditionally* — it worked by accident. Rewriting it with `format()` made it a correct boolean, which is always `false` on a tag-triggered run.

**Evidence:** step conclusion was `success` for v6.0.1 (2026-04-28) and v6.0.2 (2026-05-13), then `skipped` for v6.0.3 (2026-06-28) and v6.1.0 (2026-07-22). The `git diff v6.0.2..v6.0.3` on `release.yml` shows this `if` change is the only functional change affecting the job.

## Fix

Remove the guard. The job already runs only on `v*` tag pushes (gated upstream by `build-release`'s `if: github.repository == 'tinylibs/tinybench'`), and the checkout step already targets the default branch (`ref: ${{ github.event.repository.default_branch }}`), so an unconditional commit is correct and lands on the right branch.

```diff
       - name: Commit and push changes
-        if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         env:
```

## AI usage

An AI assistant was used to help investigate the workflow history and draft this change. I have reviewed and understand the diff.