### PR TITLE
docs: stop advertising async:false for promise-returning tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ checking if provided function is an `AsyncFunction` or if it returns a
 
 You can also explicitly set the `async` option to `true` or `false` when adding
 a task, thus avoiding the detection. Set `async: false` only for a genuinely
-synchronous task; to time the synchronous portion of a function that returns a
-`Promise`, return `overriddenDuration` instead.
+synchronous task; to measure the synchronous cost of a function that returns a
+`Promise`, record it via `overriddenDuration` instead.
 
 ```ts
 const bench = new Bench()

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ checking if provided function is an `AsyncFunction` or if it returns a
 `Promise`, by calling the provided function once.
 
 You can also explicitly set the `async` option to `true` or `false` when adding
-a task, thus avoiding the detection. This can be useful, for example, for
-functions that return a `Promise` but are actually synchronous.
+a task, thus avoiding the detection. Set `async: false` only for a genuinely
+synchronous task; to time the synchronous portion of a function that returns a
+`Promise`, return `overriddenDuration` instead.
 
 ```ts
 const bench = new Bench()
@@ -131,18 +132,6 @@ bench.add(
     return Promise.resolve()
   },
   { async: true }
-)
-
-bench.add(
-  'syncTaskReturningPromiseAsSync',
-  () => {
-    // for example running sync logic, which blocks the event loop anyway
-    // like fs.writeFileSync
-
-    // returns promise maybe for API compatibility
-    return Promise.resolve()
-  },
-  { async: false }
 )
 
 await bench.run()
@@ -333,7 +322,7 @@ const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
   Construction (and `run()`) throws if both are set.
 - For sub-overhead measurements (`X ≈ Ĉ`) the `max(0, …)` clamp
   truncates the lower tail and biases statistics; prefer
-  `overriddenDuration` (see below).
+  `overriddenDuration`.
 - When the timer is too coarse to resolve the call cost — fewer than half
   of the calibration pairs produce a positive delta (call cost `C < R / 2`,
   e.g. a `Date.now`-class timer with `>= 1 ms` resolution) — the calibration
@@ -346,7 +335,7 @@ const overhead = calibrateTimerOverhead(hrtimeNowTimestampProvider, {
 - `Ĉ` does not cover an async task's `await` microtask turn — that overhead is
   inside the measured window but absent from the calibration pairs — so async
   sub-microsecond samples stay over-measured even with `subtractTimerOverhead`.
-  Prefer `async: false` for synchronous work, or `overriddenDuration`.
+  Use `overriddenDuration` for such sub-resolution work.
 
 ## Per-Sample Override (`overriddenDuration`)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -381,9 +381,7 @@ export interface FnOptions {
    *
    * Measuring an async task awaits it inside the timed window, so each sample
    * includes one microtask-turn overhead that `subtractTimerOverhead` does not
-   * remove. For sub-microsecond synchronous work that only returns a promise,
-   * set `async: false`; otherwise prefer `overriddenDuration` for
-   * sub-resolution timings.
+   * remove. For sub-resolution timings, prefer `overriddenDuration`.
    */
   async?: boolean
 


### PR DESCRIPTION
## Summary

The docs advertise `async: false` as a way to measure "synchronous work that returns a `Promise`", but that configuration **errors at runtime**.

`#measureSync` asserts the task result is not promise-like:

```ts
assert(
  !isPromiseLike(fnResult),
  'task function must be sync when using `runSync()`'
)
```

With `async: false`, `run()` routes through `#measureSync`, so a promise-returning task ends up in `state: 'errored'` — reproducible:

```js
const bench = new Bench()
bench.add('x', () => Promise.resolve(42), { async: false })
await bench.run()
// bench.getTask('x').result.state === 'errored'
// error: "task function must be sync when using `runSync()`"
```

Two docs promised this non-working capability:

- the **README** "Async Detection" `syncTaskReturningPromiseAsSync` example (`() => Promise.resolve()` with `{ async: false }`);
- an **`FnOptions.async` JSDoc** note advising `async: false` for "synchronous work that only returns a promise".

## What this changes

Docs only — no runtime behavior change. The strict `#measureSync` assert is kept (it is correct).

- Remove the `syncTaskReturningPromiseAsSync` README example and reword the surrounding guidance.
- Reword the `FnOptions.async` JSDoc.
- Point users who want to time only the **synchronous portion** of a promise-returning function to **`overriddenDuration`**, which is explicit, safe, and already documented — e.g. `return { overriddenDuration: elapsedMs }`.

## Why not enable `async: false` for promise-returning tasks instead?

That direction was evaluated and rejected: it cannot be made safe. There is no synchronous way to distinguish an already-resolved promise (the legitimate case) from a genuinely pending one, so it silently mismeasures real async work by orders of magnitude (only the synchronous creation is timed, the `await` is dropped) with no error or warning. No peer library (benchmark.js, mitata, tatami-ng, vitest bench) offers this. `overriddenDuration` already covers the legitimate use case safely.

## AI usage

An AI assistant helped investigate and draft this change. I have reviewed and understand the diff.