### PR TITLE
fix: enforce optional signature

### DIFF
--- a/src/bench.ts
+++ b/src/bench.ts
@@ -146,7 +146,7 @@ export class Bench extends EventTarget implements BenchLike {
    * Otherwise calibrated once at construction time via
    * {@link calibrateTimerOverhead}.
    */
-  readonly timerOverhead: number | undefined
+  readonly timerOverhead?: number
 
   /**
    * A timestamp provider and its related functions.
@@ -221,16 +221,21 @@ export class Bench extends EventTarget implements BenchLike {
     this.setup = restOptions.setup ?? emptyFunction
     this.teardown = restOptions.teardown ?? emptyFunction
     this.throws = restOptions.throws ?? false
-    this.signal = restOptions.signal
+    if (restOptions.signal != null) {
+      this.signal = restOptions.signal
+    }
     this.retainSamples = restOptions.retainSamples === true
     this.subtractTimerOverhead = restOptions.subtractTimerOverhead === true
     assert(
       !(this.subtractTimerOverhead && this.concurrency === 'task'),
       subtractTimerOverheadConcurrencyError
     )
-    this.timerOverhead = this.subtractTimerOverhead
+    const timerOverhead = this.subtractTimerOverhead
       ? calibrateTimerOverhead(this.timestampProvider)
       : undefined
+    if (timerOverhead != null) {
+      this.timerOverhead = timerOverhead
+    }
 
     if (this.signal) {
       this.signal.addEventListener(

--- a/src/event.ts
+++ b/src/event.ts
@@ -69,10 +69,12 @@ class BenchEvent<
     errorOrReason?: Error | TimerSaturationReason
   ) {
     super(type)
-    this.#task = task
+    if (task != null) {
+      this.#task = task
+    }
     if (typeof errorOrReason === 'string') {
       this.#reason = errorOrReason
-    } else {
+    } else if (errorOrReason != null) {
       this.#error = errorOrReason
     }
   }

--- a/src/task.ts
+++ b/src/task.ts
@@ -622,9 +622,9 @@ export class Task extends EventTarget {
     latencySamples,
     overriddenIndices,
   }: {
-    error?: Error
-    latencySamples?: number[]
-    overriddenIndices?: Set<number>
+    error: Error | undefined
+    latencySamples: number[] | undefined
+    overriddenIndices: Set<number> | undefined
   }): void {
     if (isValidSamples(latencySamples)) {
       this.#runs = latencySamples.length

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -774,7 +774,7 @@ interface WithConcurrencyOptions<R> {
   /**
    * An optional AbortSignal to cancel the execution.
    */
-  signal?: AbortSignal
+  signal?: AbortSignal | undefined
   /**
    * The maximum amount of time to run the executions in milliseconds. If 0,
    * runs until iterations are completed.

--- a/test/utils-default-convert-task-result-for-console-table.test.ts
+++ b/test/utils-default-convert-task-result-for-console-table.test.ts
@@ -170,7 +170,7 @@ test('defaultConvertTaskResultForConsoleTable - errored - with stack', () => {
 
 test('defaultConvertTaskResultForConsoleTable - errored - without stack', () => {
   const error = new Error('Sample error')
-  error.stack = undefined
+  delete error.stack
   expect(
     defaultConvertTaskResultForConsoleTable({
       name: 'Sample Task',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "erasableSyntaxOnly": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
+    "exactOptionalPropertyTypes": true,
     "noImplicitThis": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
The same as https://github.com/tinylibs/tinybench/pull/541

With the amount of `?:` and `| undefined` in the codebase it seems like tinybench cares about the distinction, but it never enforced it. This PR enabled the flag to make sure TypeScript fails when types are defined incorrectly.

This breaks Vitest CI: https://github.com/vitest-dev/vitest/pull/10898