### PR TITLE
fix(types): preserve EventTarget listener fallbacks

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Type check
         run: pnpm typecheck
 
+      - name: Type check Workerd declarations
+        run: pnpm typecheck:workerd
+
   qa-bun:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import neostandard, { plugins } from 'neostandard'
 
 export default defineConfig([
   {
-    ignores: ['docs/**', 'package/**'],
+    ignores: ['docs/**', 'package/**', 'type-tests/workerd/**'],
   },
   cspellConfigs.recommended,
   {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260823.1",
+    "@cloudflare/workers-types": "^5.20260823.1",
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
     "@cspell/eslint-plugin": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepublishOnly": "pnpm build && rm -rf ./package && clean-publish",
     "postpublish": "rm -rf ./package",
     "typecheck": "tsc --noEmit",
+    "typecheck:workerd": "pnpm build && tsc -p type-tests/workerd/tsconfig.json",
     "typedoc": "typedoc",
     "lint": "eslint --cache src test examples eslint.config.js tsdown.config.ts vitest.config.ts vitest.pretest.config.ts",
     "lint:fix": "eslint --cache --fix src test examples eslint.config.js tsdown.config.ts vitest.config.ts vitest.pretest.config.ts",
@@ -49,6 +50,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@cloudflare/workers-types": "5.20260823.1",
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
     "@cspell/eslint-plugin": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
   .:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260823.1
+        specifier: ^5.20260823.1
         version: 5.20260823.1
       '@commitlint/cli':
         specifier: ^21.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
 
   .:
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 5.20260823.1
+        version: 5.20260823.1
       '@commitlint/cli':
         specifier: ^21.2.2
         version: 21.2.2(@types/node@24.13.3)(conventional-commits-parser@7.1.2)(typescript@6.0.3)
@@ -119,6 +122,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@cloudflare/workers-types@5.20260823.1':
+    resolution: {integrity: sha512-HdBVDR/gecQ5QwB+DZ9kB5yjNZLS85fe8bMB2K/k0xmCvaoMlAFrQQGLaCBYR00j+i9aTkQzwfrPInVZwlMPwQ==}
 
   '@commitlint/cli@21.2.2':
     resolution: {integrity: sha512-a+6hQxIxnpdvSvS2apvttPNbEliYsVC3PqFYDiiB2kjbwIsQsj1urvQ4Tkf70pKYozPalKAuRQmm/GHwndduqA==}
@@ -3378,6 +3384,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@cloudflare/workers-types@5.20260823.1': {}
 
   '@commitlint/cli@21.2.2(@types/node@24.13.3)(conventional-commits-parser@7.1.2)(typescript@6.0.3)':
     dependencies:

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -41,11 +41,11 @@ const subtractTimerOverheadConcurrencyError =
  * The Bench class keeps track of the benchmark tasks and controls them.
  */
 export class Bench extends EventTarget implements BenchLike {
-  declare addEventListener: <K extends BenchEvents>(
+  declare addEventListener: (<K extends BenchEvents>(
     type: K,
     listener: EventListener<K> | EventListenerObject<K> | null,
     options?: AddEventListenerOptionsArgument
-  ) => void
+  ) => void) & EventTarget['addEventListener']
 
   /**
    * Executes tasks concurrently based on the specified concurrency mode.
@@ -74,11 +74,11 @@ export class Bench extends EventTarget implements BenchLike {
   /**
    * Removes a previously registered event listener.
    */
-  declare removeEventListener: <K extends BenchEvents>(
+  declare removeEventListener: (<K extends BenchEvents>(
     type: K,
     listener: EventListener<K> | EventListenerObject<K> | null,
     options?: RemoveEventListenerOptionsArgument
-  ) => void
+  ) => void) & EventTarget['removeEventListener']
 
   readonly retainSamples: boolean
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -72,17 +72,17 @@ const startedTaskResult: TaskResult = { state: 'started' }
  * results, name, the task function, the number times the task function has been executed, ...
  */
 export class Task extends EventTarget {
-  declare addEventListener: <K extends TaskEvents>(
+  declare addEventListener: (<K extends TaskEvents>(
     type: K,
     listener: EventListener<K, 'task'> | EventListenerObject<K, 'task'> | null,
     options?: AddEventListenerOptionsArgument
-  ) => void
+  ) => void) & EventTarget['addEventListener']
 
-  declare removeEventListener: <K extends TaskEvents>(
+  declare removeEventListener: (<K extends TaskEvents>(
     type: K,
     listener: EventListener<K, 'task'> | EventListenerObject<K, 'task'> | null,
     options?: RemoveEventListenerOptionsArgument
-  ) => void
+  ) => void) & EventTarget['removeEventListener']
 
   /**
    * The estimated effective timer resolution observed during the last run,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type { BenchEvent } from '../src/event'
  * Options for adding an event listener
  */
 export type AddEventListenerOptionsArgument = Parameters<
-  typeof EventTarget.prototype.addEventListener
+  EventTarget['addEventListener']
 >[2]
 
 /**
@@ -462,7 +462,7 @@ export type NowFn = () => number
 
 // @types/node doesn't have these types globally, and we don't want to bring "dom" lib for everyone
 export type RemoveEventListenerOptionsArgument = Parameters<
-  typeof EventTarget.prototype.removeEventListener
+  EventTarget['removeEventListener']
 >[2]
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,11 +52,11 @@ export interface BenchLike extends EventTarget {
   /**
    * Adds a listener for the specified event type.
    */
-  addEventListener: <K extends BenchEvents>(
+  addEventListener: (<K extends BenchEvents>(
     type: K,
     listener: EventListener<K> | EventListenerObject<K> | null,
     options?: AddEventListenerOptionsArgument
-  ) => void
+  ) => void) & EventTarget['addEventListener']
   /**
    * Executes tasks concurrently based on the specified concurrency mode, if set.
    *
@@ -77,11 +77,11 @@ export interface BenchLike extends EventTarget {
   /**
    * Removes a previously registered event listener.
    */
-  removeEventListener: <K extends BenchEvents>(
+  removeEventListener: (<K extends BenchEvents>(
     type: K,
     listener: EventListener<K> | EventListenerObject<K> | null,
     options?: RemoveEventListenerOptionsArgument
-  ) => void
+  ) => void) & EventTarget['removeEventListener']
 
   /**
    * Should samples be retained for further custom processing

--- a/test/events-properties.test.ts
+++ b/test/events-properties.test.ts
@@ -1,19 +1,36 @@
-import { test } from 'vitest'
+import { expectTypeOf, test } from 'vitest'
 
-import { Bench, type Task } from '../src'
+import {
+  Bench,
+  type BenchEvent,
+  type BenchLike,
+  type Task,
+} from '../src'
 
-/**
- * This helper function is used to assert that a value is assignable to a specific type.
- * It does not produce any runtime code and is only used for type checking during development.
- * @param value - The value to be checked for type assignability.
- * @returns The same value that was passed in.
- */
-function expectAssignable<T> (value: T) {
-  return value
-}
+type NativeAddEventListenerParameters = Parameters<
+  EventTarget['addEventListener']
+>
+type NativeRemoveEventListenerParameters = Parameters<
+  EventTarget['removeEventListener']
+>
 
 test('events properties', () => {
-  const bench = new Bench()
+  const bench = new Bench().add('foo', () => undefined)
+  const benchLike: BenchLike = bench
+
+  // The native fallback must remain the final overload on every public surface.
+  expectTypeOf<Parameters<Bench['addEventListener']>>()
+    .toEqualTypeOf<NativeAddEventListenerParameters>()
+  expectTypeOf<Parameters<Bench['removeEventListener']>>()
+    .toEqualTypeOf<NativeRemoveEventListenerParameters>()
+  expectTypeOf<Parameters<Task['addEventListener']>>()
+    .toEqualTypeOf<NativeAddEventListenerParameters>()
+  expectTypeOf<Parameters<Task['removeEventListener']>>()
+    .toEqualTypeOf<NativeRemoveEventListenerParameters>()
+  expectTypeOf<Parameters<BenchLike['addEventListener']>>()
+    .toEqualTypeOf<NativeAddEventListenerParameters>()
+  expectTypeOf<Parameters<BenchLike['removeEventListener']>>()
+    .toEqualTypeOf<NativeRemoveEventListenerParameters>()
 
   const fooTask = bench.getTask('foo')
 
@@ -22,84 +39,120 @@ test('events properties', () => {
   // Task events
 
   fooTask.addEventListener('abort', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'abort', 'task'>>()
   })
 
   fooTask.addEventListener('complete', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'complete', 'task'>>()
   })
 
   fooTask.addEventListener('cycle', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'cycle', 'task'>>()
   })
 
   fooTask.addEventListener('error', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'error', 'task'>>()
   })
 
   fooTask.addEventListener('reset', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'reset', 'task'>>()
   })
 
   fooTask.addEventListener('start', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'start', 'task'>>()
   })
 
   fooTask.addEventListener('warmup', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'warmup', 'task'>>()
+  })
+
+  fooTask.addEventListener('custom', evt => {
+    expectTypeOf(evt).not.toBeAny()
+    expectTypeOf(evt).toEqualTypeOf<Event>()
+  })
+
+  fooTask.removeEventListener('custom', evt => {
+    expectTypeOf(evt).not.toBeAny()
+    expectTypeOf(evt).toEqualTypeOf<Event>()
+  })
+
+  fooTask.removeEventListener('abort', evt => {
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'abort', 'task'>>()
   })
 
   // Bench events
 
   bench.addEventListener('abort', evt => {
-    expectAssignable<Task | undefined>(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'abort'>>()
   })
 
   bench.addEventListener('add', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'add'>>()
   })
 
   bench.addEventListener('complete', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'complete'>>()
   })
 
   bench.addEventListener('cycle', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'cycle'>>()
   })
 
   bench.addEventListener('error', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'error'>>()
   })
 
   bench.addEventListener('remove', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'remove'>>()
   })
 
   bench.addEventListener('reset', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'reset'>>()
   })
 
   bench.addEventListener('start', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'start'>>()
+  })
+
+  bench.addEventListener('warning', evt => {
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'warning'>>()
   })
 
   bench.addEventListener('warmup', evt => {
-    expectAssignable(evt.task)
-    expectAssignable(evt.error)
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'warmup'>>()
+  })
+
+  bench.addEventListener('custom', evt => {
+    expectTypeOf(evt).not.toBeAny()
+    expectTypeOf(evt).toEqualTypeOf<Event>()
+  })
+
+  bench.removeEventListener('custom', evt => {
+    expectTypeOf(evt).not.toBeAny()
+    expectTypeOf(evt).toEqualTypeOf<Event>()
+  })
+
+  bench.removeEventListener('abort', evt => {
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'abort'>>()
+  })
+
+  // BenchLike events
+
+  benchLike.addEventListener('abort', evt => {
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'abort'>>()
+  })
+
+  benchLike.removeEventListener('abort', evt => {
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'abort'>>()
+  })
+
+  benchLike.addEventListener('custom', evt => {
+    expectTypeOf(evt).not.toBeAny()
+    expectTypeOf(evt).toEqualTypeOf<Event>()
+  })
+
+  benchLike.removeEventListener('custom', evt => {
+    expectTypeOf(evt).not.toBeAny()
+    expectTypeOf(evt).toEqualTypeOf<Event>()
   })
 })

--- a/test/events-properties.test.ts
+++ b/test/events-properties.test.ts
@@ -66,6 +66,10 @@ test('events properties', () => {
     expectTypeOf(evt).toEqualTypeOf<BenchEvent<'warmup', 'task'>>()
   })
 
+  fooTask.addEventListener('warning', evt => {
+    expectTypeOf(evt).toEqualTypeOf<BenchEvent<'warning', 'task'>>()
+  })
+
   fooTask.addEventListener('custom', evt => {
     expectTypeOf(evt).not.toBeAny()
     expectTypeOf(evt).toEqualTypeOf<Event>()

--- a/type-tests/workerd/consumer.ts
+++ b/type-tests/workerd/consumer.ts
@@ -57,6 +57,25 @@ benchLike.removeEventListener('custom', event => {
   expectType<IsExact<typeof event, Event>>(true)
 })
 
+bench.addEventListener(
+  'custom',
+  {
+    handleEvent (event) {
+      expectType<IsExact<typeof event, Event>>(true)
+    },
+  },
+  { once: true }
+)
+benchLike.removeEventListener(
+  'custom',
+  {
+    handleEvent (event) {
+      expectType<IsExact<typeof event, Event>>(true)
+    },
+  },
+  { capture: true }
+)
+
 bench.removeEventListener('abort', event => {
   expectType<IsExact<typeof event, BenchEvent<'abort'>>>(true)
 })

--- a/type-tests/workerd/consumer.ts
+++ b/type-tests/workerd/consumer.ts
@@ -7,6 +7,12 @@ import {
 
 type IsAny<T> = 0 extends 1 & T ? true : false
 
+type IsExact<Actual, Expected> = IsAny<Actual> extends true
+  ? false
+  : [Actual, Expected] extends [Expected, Actual]
+      ? true
+      : false
+
 export declare class BenchCompatibility extends EventTarget {
   addEventListener: Bench['addEventListener']
   removeEventListener: Bench['removeEventListener']
@@ -33,44 +39,38 @@ if (task == null) {
 }
 
 bench.addEventListener('custom', event => {
-  expectType<IsAny<typeof event>>(false)
-  expectType<Event>(event)
+  expectType<IsExact<typeof event, Event>>(true)
 })
 bench.removeEventListener('custom', event => {
-  expectType<IsAny<typeof event>>(false)
-  expectType<Event>(event)
+  expectType<IsExact<typeof event, Event>>(true)
 })
 task.addEventListener('custom', event => {
-  expectType<IsAny<typeof event>>(false)
-  expectType<Event>(event)
+  expectType<IsExact<typeof event, Event>>(true)
 })
 task.removeEventListener('custom', event => {
-  expectType<IsAny<typeof event>>(false)
-  expectType<Event>(event)
+  expectType<IsExact<typeof event, Event>>(true)
 })
 benchLike.addEventListener('custom', event => {
-  expectType<IsAny<typeof event>>(false)
-  expectType<Event>(event)
+  expectType<IsExact<typeof event, Event>>(true)
 })
 benchLike.removeEventListener('custom', event => {
-  expectType<IsAny<typeof event>>(false)
-  expectType<Event>(event)
+  expectType<IsExact<typeof event, Event>>(true)
 })
 
 bench.removeEventListener('abort', event => {
-  expectType<BenchEvent<'abort'>>(event)
+  expectType<IsExact<typeof event, BenchEvent<'abort'>>>(true)
 })
 task.removeEventListener('abort', event => {
-  expectType<BenchEvent<'abort', 'task'>>(event)
+  expectType<IsExact<typeof event, BenchEvent<'abort', 'task'>>>(true)
 })
 benchLike.removeEventListener('abort', event => {
-  expectType<BenchEvent<'abort'>>(event)
+  expectType<IsExact<typeof event, BenchEvent<'abort'>>>(true)
 })
 
 task.addEventListener(
   'abort',
   event => {
-    expectType<BenchEvent<'abort', 'task'>>(event)
+    expectType<IsExact<typeof event, BenchEvent<'abort', 'task'>>>(true)
   },
   { once: true }
 )
@@ -78,7 +78,7 @@ task.removeEventListener(
   'abort',
   {
     handleEvent (event) {
-      expectType<BenchEvent<'abort', 'task'>>(event)
+      expectType<IsExact<typeof event, BenchEvent<'abort', 'task'>>>(true)
     },
   },
   { capture: true }

--- a/type-tests/workerd/consumer.ts
+++ b/type-tests/workerd/consumer.ts
@@ -1,0 +1,92 @@
+import {
+  Bench,
+  type BenchEvent,
+  type BenchLike,
+  type Task,
+} from '../../dist/index.js'
+
+type IsAny<T> = 0 extends 1 & T ? true : false
+
+export declare class BenchCompatibility extends EventTarget {
+  addEventListener: Bench['addEventListener']
+  removeEventListener: Bench['removeEventListener']
+}
+
+export declare class BenchLikeCompatibility extends EventTarget {
+  addEventListener: BenchLike['addEventListener']
+  removeEventListener: BenchLike['removeEventListener']
+}
+
+export declare class TaskCompatibility extends EventTarget {
+  addEventListener: Task['addEventListener']
+  removeEventListener: Task['removeEventListener']
+}
+
+declare function expectType<T> (value: T, expected?: T): void
+
+const bench = new Bench().add('task', () => undefined)
+const task = bench.getTask('task')
+const benchLike: BenchLike = bench
+
+if (task == null) {
+  throw new Error('Expected the benchmark task to exist')
+}
+
+bench.addEventListener('custom', event => {
+  expectType<IsAny<typeof event>>(false)
+  expectType<Event>(event)
+})
+bench.removeEventListener('custom', event => {
+  expectType<IsAny<typeof event>>(false)
+  expectType<Event>(event)
+})
+task.addEventListener('custom', event => {
+  expectType<IsAny<typeof event>>(false)
+  expectType<Event>(event)
+})
+task.removeEventListener('custom', event => {
+  expectType<IsAny<typeof event>>(false)
+  expectType<Event>(event)
+})
+benchLike.addEventListener('custom', event => {
+  expectType<IsAny<typeof event>>(false)
+  expectType<Event>(event)
+})
+benchLike.removeEventListener('custom', event => {
+  expectType<IsAny<typeof event>>(false)
+  expectType<Event>(event)
+})
+
+bench.removeEventListener('abort', event => {
+  expectType<BenchEvent<'abort'>>(event)
+})
+task.removeEventListener('abort', event => {
+  expectType<BenchEvent<'abort', 'task'>>(event)
+})
+benchLike.removeEventListener('abort', event => {
+  expectType<BenchEvent<'abort'>>(event)
+})
+
+task.addEventListener(
+  'abort',
+  event => {
+    expectType<BenchEvent<'abort', 'task'>>(event)
+  },
+  { once: true }
+)
+task.removeEventListener(
+  'abort',
+  {
+    handleEvent (event) {
+      expectType<BenchEvent<'abort', 'task'>>(event)
+    },
+  },
+  { capture: true }
+)
+task.addEventListener('abort', null, true)
+task.removeEventListener('abort', null, true)
+
+// @ts-expect-error EventTarget event names are strings
+bench.addEventListener(1, () => undefined)
+// @ts-expect-error EventTarget event names are strings
+bench.removeEventListener(1, () => undefined)

--- a/type-tests/workerd/tsconfig.json
+++ b/type-tests/workerd/tsconfig.json
@@ -1,13 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "types": ["@cloudflare/workers-types"],
-    "strict": true,
-    "skipLibCheck": true,
-    "noEmit": true
+    "types": ["@cloudflare/workers-types"]
   },
-  "files": ["consumer.ts"]
+  "include": ["consumer.ts"]
 }

--- a/type-tests/workerd/tsconfig.json
+++ b/type-tests/workerd/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "files": ["consumer.ts"]
+}


### PR DESCRIPTION
## Summary

- preserve Tinybench-specific listener inference while deriving ambient listener and option fallbacks from the default `EventTarget` instance signatures
- avoid generic prototype erasure to an `any` event map in Workerd, keeping custom event names as `string` and callback events as `Event`
- cover known and custom add/remove inference for functions, listener objects, options, and `null` across `Bench`, `Task`, and `BenchLike`
- permanently compile the emitted declaration against Cloudflare Workers types using the project's standard caret dependency range

Fixes #644.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm typecheck:workerd` with `@cloudflare/workers-types@^5.20260823.1`
- `pnpm test` (64 files, 241 tests)
- `pnpm lint`
- `pnpm lint:typedoc`
- verified the Workerd consumer covers all six `Bench`/`Task`/`BenchLike` add/remove surfaces, exact known/custom callback types, listener objects, options, `null`, and rejection of numeric event names
- verified a prototype-based mutant fails the permanent consumer with eight `any` inference errors and two unused numeric-name expectations
- replayed the exact Wrangler 4.126.0 / TypeScript 7.0.2 reproduction: all listener inheritance diagnostics (`TS2416`/`TS2430`) are eliminated

The dedicated consumer uses `skipLibCheck: true` to isolate this listener contract while checking compatibility classes and call sites in source. The exact Wrangler fixture remains globally red only for the two separate `main` declaration issues involving `globalThis.Event` (`TS2339`) and `DOMHighResTimeStamp` (`TS2304`).