### PR TITLE
fix: guard Bun.version when only process.versions.bun is present

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,13 @@ export function detectRuntime (g = globalThis as Record<string, unknown>): {
       (g.process as { versions?: Record<string, string> }).versions?.bun)
   ) {
     runtime = 'bun'
-    version = (g.Bun as { version: string }).version || 'unknown'
+    // `process.versions.bun` can be set without a `Bun` global, e.g. inside a
+    // `node:vm` context that was handed the host `process` (vitest's vm pools).
+    version =
+      (g.Bun as undefined | { version?: string })?.version ??
+      (g.process as undefined | { versions?: Record<string, string> })
+        ?.versions?.bun ??
+      'unknown'
   } else if (g.Deno) {
     runtime = 'deno'
     version =

--- a/test/utils-detect-runtime.test.ts
+++ b/test/utils-detect-runtime.test.ts
@@ -29,6 +29,19 @@ test('detect runtime bun with version', () => {
   expect(version).toBe('0.5.0')
 })
 
+test('detect runtime bun from process.versions without Bun global', () => {
+  const { runtime, version } = detectRuntime({
+    process: {
+      versions: {
+        bun: '1.4.0',
+      },
+    },
+  })
+
+  expect(runtime).toBe('bun')
+  expect(version).toBe('1.4.0')
+})
+
 test('detect runtime node', () => {
   const { runtime, version } = detectRuntime({
     process: {


### PR DESCRIPTION
### Problem

`detectRuntime` enters the bun branch when `process.versions.bun` is set, then reads `globalThis.Bun.version` without a guard:

```ts
if (g.Bun || (g.process && g.process.versions?.bun)) {
  runtime = 'bun'
  version = (g.Bun as { version: string }).version || 'unknown'
```

A `node:vm` context can satisfy the first half without the second. vitest's `vmThreads` and `vmForks` pools hand the context the host `process` but no `Bun` global, so under Bun every test file that imports vitest's runner (which pulls in tinybench for `bench`) dies at module evaluation:

```
TypeError: undefined is not an object (evaluating 'e.Bun.version')
 ❯ r unknown:1052:78          # tinybench/dist/index.js, detectRuntime
 ❯ evaluate node:vm:176:42
 ❯ evaluateModule node_modules/vitest/dist/chunks/vm.*.js:633:38
```

Node never enters that branch, so it is invisible there. A vitest-free repro:

```js
import vm from "node:vm";
const ctx = vm.createContext({ process });
vm.runInContext(`(e => e.Bun || e.process?.versions?.bun ? e.Bun.version : "other")(globalThis)`, ctx);
// bun:  TypeError: undefined is not an object (evaluating 'e.Bun.version')
// node: "other"
```

### Fix

Read the version from `Bun` when present, else from `process.versions.bun`, else `'unknown'`. The same file already guards `Bun?.nanoseconds` the same way further down.

### Verification

- `test/utils-detect-runtime.test.ts`: new case `detect runtime bun from process.versions without Bun global`. Fails on `main` with the TypeError above, passes with the fix; the other 22 cases unchanged.
- `eslint` on the two files and `tsc --noEmit` clean.
- With this guard applied to the installed `tinybench/dist/index.js`, a 131-file vitest 5 suite (node + happy-dom projects) run with `--pool=vmThreads` under Bun goes from 21 unhandled evaluation errors to the same result Node produces.
