### PR TITLE
fix: preserve Bun version fallback semantics

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,11 +37,17 @@ export function detectRuntime (g = globalThis as Record<string, unknown>): {
     runtime = 'bun'
     // `process.versions.bun` can be set without a `Bun` global, e.g. inside a
     // `node:vm` context that was handed the host `process` (vitest's vm pools).
-    version =
-      (g.Bun as undefined | { version?: string })?.version ??
-      (g.process as undefined | { versions?: Record<string, string> })
-        ?.versions?.bun ??
-      'unknown'
+    const bunVersion = (g.Bun as undefined | { version?: string })?.version
+    if (bunVersion) {
+      version = bunVersion
+    } else {
+      const processBunVersion = (
+        g.process as undefined | { versions?: Record<string, string> }
+      )?.versions?.bun
+      if (processBunVersion) {
+        version = processBunVersion
+      }
+    }
   } else if (g.Deno) {
     runtime = 'deno'
     version =

--- a/test/utils-detect-runtime.test.ts
+++ b/test/utils-detect-runtime.test.ts
@@ -29,6 +29,22 @@ test('detect runtime bun with version', () => {
   expect(version).toBe('0.5.0')
 })
 
+test('detect runtime bun with empty versions', () => {
+  const { runtime, version } = detectRuntime({
+    Bun: {
+      version: '',
+    },
+    process: {
+      versions: {
+        bun: '',
+      },
+    },
+  })
+
+  expect(runtime).toBe('bun')
+  expect(version).toBe('unknown')
+})
+
 test('detect runtime bun from process.versions without Bun global', () => {
   const { runtime, version } = detectRuntime({
     process: {


### PR DESCRIPTION
Follow-up to #655.

## Summary

- treat empty Bun runtime version values as unavailable
- fall back to `process.versions.bun`, then preserve the existing `unknown` result
- cover the empty-string regression for both version sources

## Verification

- targeted reproduction: before `{"runtime":"bun","version":""}`, after `{"runtime":"bun","version":"unknown"}`
- `pnpm test test/utils-detect-runtime.test.ts` — 24 passed
- `bun test test/utils-detect-runtime.test.ts` — 24 passed
- `pnpm test` — 64 files, 243 tests passed
- `pnpm typecheck`
- `pnpm exec eslint src/utils.ts test/utils-detect-runtime.test.ts`
- `pnpm build`