### PR TITLE
fix(types): support non-DOM runtime declarations

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -7,6 +7,10 @@ import type {
   TimerSaturationReason,
 } from './types'
 
+// Workerd defines `Event.type` as an accessor, which a subclass cannot narrow
+// with a declared property. Remove it from the base type before restoring `K`.
+const EventBase: new (type: string) => Omit<Event, 'type'> = globalThis.Event
+
 /**
  * The BenchEvent class represents events that occur during the benchmarking
  * process.
@@ -14,7 +18,7 @@ import type {
 class BenchEvent<
   K extends BenchEvents = BenchEvents,
   M extends 'bench' | 'task' = 'bench'
-> extends globalThis.Event {
+> extends EventBase {
   declare type: K
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -890,7 +890,7 @@ export const withConcurrency = async <R>(
  * Returns the current timestamp in milliseconds using `performance.now()`.
  * @returns the current timestamp in milliseconds
  */
-export const performanceNow = globalThis.performance.now.bind(
+export const performanceNow: NowFn = globalThis.performance.now.bind(
   globalThis.performance
 )
 

--- a/type-tests/workerd/consumer.ts
+++ b/type-tests/workerd/consumer.ts
@@ -78,6 +78,7 @@ benchLike.removeEventListener(
 
 bench.removeEventListener('abort', event => {
   expectType<IsExact<typeof event, BenchEvent<'abort'>>>(true)
+  expectType<IsExact<typeof event.type, 'abort'>>(true)
 })
 task.removeEventListener('abort', event => {
   expectType<IsExact<typeof event, BenchEvent<'abort', 'task'>>>(true)

--- a/type-tests/workerd/tsconfig.json
+++ b/type-tests/workerd/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "ESNext",
-    "types": ["@cloudflare/workers-types"]
+    "types": ["@cloudflare/workers-types"],
+    "skipLibCheck": false
   },
   "include": ["consumer.ts"]
 }


### PR DESCRIPTION
## Summary

- make the emitted `BenchEvent` declaration compatible with runtimes whose `Event` constructor is not exposed through `typeof globalThis`
- type `performanceNow` as the existing `NowFn` contract so the declaration returns `number` instead of leaking `DOMHighResTimeStamp`
- compile the emitted bundle against Workerd types with `skipLibCheck: false`, while preserving the literal `BenchEvent.type` contract

## Root cause

Two source-level DOM details leaked into the public declaration bundle:

1. `BenchEvent extends globalThis.Event` was emitted verbatim. Wrangler-generated Workerd declarations provide the global `Event` type, but do not expose `Event` as a property of `typeof globalThis`.
2. `performance.now.bind(...)` had no explicit annotation, so TypeScript inferred the DOM alias `DOMHighResTimeStamp` instead of Tinybench's runtime-neutral `NowFn` return type.

The existing Workerd consumer inherited `skipLibCheck: true` from the root configuration. It validated listener call sites but did not validate `dist/index.d.ts`, allowing both ambient-type leaks through. These two diagnostics predated and were explicitly out of scope for #646.

## Design

- expose an `EventBase` construct signature that omits only the base `type` member, then retain `BenchEvent<K>["type"]` as `K`
- annotate `performanceNow` with `NowFn`; runtime behavior stays unchanged
- override `skipLibCheck` in the permanent Workerd declaration consumer

## Verification

- exact issue fixture, Wrangler 4.129.0 / TypeScript 6.0.3: two diagnostics before, zero after
- `pnpm typecheck:workerd`
- `pnpm test` — 64 files, 243 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:typedoc`
- `pnpm build`

Closes #658.