### PR TITLE
fix: avoid ambient type leaks in declarations

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -14,7 +14,7 @@ import type {
 class BenchEvent<
   K extends BenchEvents = BenchEvents,
   M extends 'bench' | 'task' = 'bench'
-> extends globalThis.Event {
+> extends Event {
   declare type: K
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -890,7 +890,7 @@ export const withConcurrency = async <R>(
  * Returns the current timestamp in milliseconds using `performance.now()`.
  * @returns the current timestamp in milliseconds
  */
-export const performanceNow = globalThis.performance.now.bind(
+export const performanceNow: NowFn = globalThis.performance.now.bind(
   globalThis.performance
 )
 


### PR DESCRIPTION
Fixes #658.

The generated declarations currently leak two ambient types from Tinybench's build environment:

- `BenchEvent` extends `globalThis.Event`
- `performanceNow` is inferred as returning `DOMHighResTimeStamp`

These declarations fail for consumers that intentionally don't include `lib.dom`, including the Workerd reproduction from #658 and strict Node-only consumers.

This change:

- uses `Event` directly for `BenchEvent`
- explicitly types `performanceNow` as the existing `NowFn` (`() => number`)

The runtime behavior is unchanged; the changes only prevent environment-specific ambient types from leaking into the published declarations.